### PR TITLE
feat: Setup - project skeleton with interface contracts and stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build artifacts
+build/
+*.o
+*.elf
+*.bin
+*.hex
+*.map
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,97 @@
+# ===========================================================================
+# CMakeLists.txt — AEB System for Zephyr RTOS
+# ===========================================================================
+# Project: Autonomous Emergency Braking (AEB)
+# Version: 1.0 (Sprint 0 — Project Skeleton)
+# Standard: MISRA C:2012, ISO 26262 ASIL B
+# ===========================================================================
+
+cmake_minimum_required(VERSION 3.20.0)
+
+# --- Zephyr project setup ---------------------------------------------------
+# In a full Zephyr environment, find_package(Zephyr) sets up the toolchain,
+# kernel, and devicetree. For PC-based compilation and unit testing without
+# Zephyr SDK, we fall back to a standard C project.
+# ---------------------------------------------------------------------------
+find_package(Zephyr QUIET)
+
+if(Zephyr_FOUND)
+    # ---- Zephyr build (target hardware / QEMU) ----------------------------
+    project(aeb_system LANGUAGES C)
+
+    target_include_directories(app PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    target_sources(app PRIVATE
+        # Entry point
+        src/main.c
+
+        # Task A — Perception
+        src/perception/aeb_perception.c
+
+        # Task B — Decision Logic
+        src/decision/aeb_ttc.c
+        src/decision/aeb_fsm.c
+
+        # Task C — Execution
+        src/execution/aeb_pid.c
+        src/execution/aeb_alert.c
+
+        # Task D — CAN Bus
+        src/communication/aeb_can.c
+
+        # Task E — UDS Diagnostics
+        src/communication/aeb_uds.c
+    )
+
+else()
+    # ---- Native / PC build (GCC, unit testing) ----------------------------
+    project(aeb_system LANGUAGES C)
+
+    # Strict MISRA-aligned warnings
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+    set(CMAKE_C_EXTENSIONS OFF)
+
+    add_compile_options(
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Werror
+        -Wshadow
+        -Wconversion
+        -Wdouble-promotion
+        -Wformat=2
+        -Wundef
+        -fno-common
+    )
+
+    # Include path
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+    # ---- Main application library (all modules) ---------------------------
+    add_library(aeb_modules STATIC
+        src/perception/aeb_perception.c
+        src/decision/aeb_ttc.c
+        src/decision/aeb_fsm.c
+        src/execution/aeb_pid.c
+        src/execution/aeb_alert.c
+        src/communication/aeb_can.c
+        src/communication/aeb_uds.c
+    )
+
+    # ---- Main executable --------------------------------------------------
+    add_executable(aeb_main src/main.c)
+    target_link_libraries(aeb_main PRIVATE aeb_modules)
+
+    # ---- Unit test executables (one per module) ---------------------------
+    # Tests are added as they are implemented during Sprint 1.
+    # Example:
+    #   add_executable(test_pid tests/test_pid.c)
+    #   target_link_libraries(test_pid PRIVATE aeb_modules)
+    #
+    #   add_executable(test_alert tests/test_alert.c)
+    #   target_link_libraries(test_alert PRIVATE aeb_modules)
+
+endif()

--- a/README.md
+++ b/README.md
@@ -1,44 +1,172 @@
-# 🚗 Autonomous Emergency Braking (AEB) System
-![CI Build](https://img.shields.io/badge/build-passing-brightgreen) ![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen) ![MISRA-C](https://img.shields.io/badge/compliance-MISRA--C-blue)
+# **Autonomous Emergency Braking (AEB)**  
 
-**CIn UFPE & Stellantis Technological Residence - Final Project**
+> Technological Residency in Embedded Software Development for the Automotive Sector  
+> Federal University of Pernambuco (UFPE) · Center for Informatics · Stellantis
 
-## 📌 Project Overview
-This repository contains the full embedded software implementation of an Autonomous Emergency Braking (AEB) system. The project strictly follows the automotive V-Model lifecycle, covering requirements engineering, Simulink modeling, C-code implementation, and 3D simulation.
+![MISRA C](https://img.shields.io/badge/MISRA%20C-2012-blue)
+![ISO 26262](https://img.shields.io/badge/ISO-26262-orange)
+![UNECE R152](https://img.shields.io/badge/UNECE-R152-green)
+![ISO 14229](https://img.shields.io/badge/ISO-14229-lightgrey)
+![Status](https://img.shields.io/badge/Status-Academic%20Project-informational)
 
-The system is designed to detect rear-end collision risks (CCRs, CCRm, CCRb scenarios) and autonomously apply braking interventions to avoid or mitigate impacts, adhering to **Euro NCAP** and **UNECE R152** standards.
+---
 
-## 🛠️ Technology Stack & Tools
-*   **Core Implementation:** C (MISRA C:2012 compliant)
-*   **Modeling & Control:** MATLAB / Simulink / Stateflow
-*   **Testing & Validation:** Google Test (C++), gcov (Coverage)
-*   **Simulation Environment:** Gazebo 3D / ROS 2
-*   **CI/CD Pipeline:** GitHub Actions (Automated build, test, and static analysis)
+## Overview
 
-## 🧪 Testing & Quality Assurance
-Safety is our top priority. Our CI/CD pipeline enforces:
-*   **Static Analysis:** 100% compliance with mandatory MISRA C rules via `cppcheck`.
-*   **Unit Testing:** Fully automated test suites.
-*   **Coverage:** 100% Statement and Branch Coverage, with **MC/DC (Modified Condition/Decision Coverage)** applied to safety-critical decision logic (ASIL B adherence).
+This repository contains the requirements baseline, model-based design artefacts, software implementation assets, and configuration-management workflow for an **Autonomous Emergency Braking (AEB)** system focused on **rear-end collision mitigation**.
 
-## 📚 Documentation
-All detailed engineering artifacts are documented in our [Project Wiki](https://github.com/jessica-leoa/aeb-project/wiki). 
+The system is designed to detect imminent rear-end collision risk with a vehicle ahead, warn the driver, and autonomously apply progressive braking when required to avoid or mitigate impact severity.
 
-* [System Requirements & Traceability Matrix](https://github.com/jessica-leoa/aeb-project/wiki/System-Requirements)
-* [Software Architecture & Stateflow](https://github.com/jessica-leoa/aeb-project/wiki/Architecture)
-* [Verification & Validation Plan (Testing Scenarios)](https://github.com/jessica-leoa/aeb-project/wiki/Validation-Plan)
+The current project baseline is limited to **longitudinal control only**. No lateral collision-avoidance manoeuvres, such as steering interventions, are included.
 
-## 🚀 How to Build and Run Tests
-```bash
-# Clone the repository
-git clone https://github.com/jessica-leoa/aeb-project.git
-cd aeb-project
+---
 
-# Compile the tests (Requires GCC)
-gcc -O0 --coverage test/test_aeb_logic.c src/aeb_logic.c -o aeb_test
+## Project Scope
 
-# Run the test suite
-./aeb_test
+The AEB baseline documented in this repository is defined by the following characteristics:
 
-# Generate Coverage Report
-gcov src/aeb_logic.c
+- rear-end collision mitigation against a vehicle ahead
+- operation in the **10–60 km/h** ego-vehicle speed range
+- dual decision criterion based on **Time-To-Collision (TTC)** and **minimum braking distance**
+- progressive intervention through a **7-state Finite State Machine**
+- communication support through **CAN**
+- diagnostic support through **UDS**
+- traceability from **requirements → model → C implementation → Tests**
+
+### In Scope
+
+- **CCRs** — Car-to-Car Rear Stationary
+- **CCRm** — Car-to-Car Rear Moving
+- **CCRb** — Car-to-Car Rear Braking
+- requirements engineering and traceability
+- MIL-oriented model validation
+- embedded C implementation aligned with the validated design baseline
+- software quality constraints derived from MISRA C and ISO 26262-oriented practices
+
+### Out of Scope
+
+- vulnerable road users (pedestrians, cyclists)
+- lateral collision avoidance
+- production ECU electrical integration
+- real sensor-fusion deployment
+- adverse weather and complex road geometries beyond straight longitudinal scenarios
+
+---
+## Operational States
+
+The validated AEB state machine contains seven states:
+
+1. **OFF**
+2. **STANDBY**
+3. **WARNING**
+4. **BRAKE_L1**
+5. **BRAKE_L2**
+6. **BRAKE_L3**
+7. **POST_BRAKE**
+
+```mermaid
+flowchart LR
+    OFF(["OFF"])
+    STANDBY(["STANDBY"])
+    WARNING(["WARNING<br/>visual + audible alert"])
+    L1(["BRAKE_L1<br/>−2 m/s²"])
+    L2(["BRAKE_L2<br/>−4 m/s²"])
+    L3(["BRAKE_L3<br/>−6 m/s²"])
+    PB(["POST_BRAKE<br/>−6 m/s² · 2 s"])
+
+    OFF -->|"clean system status"| STANDBY
+    STANDBY -->|"sensor fault"| OFF
+    STANDBY -->|"TTC ≤ 4.0 s"| WARNING
+    WARNING -->|"TTC > 4.0 s for 200 ms"| STANDBY
+    WARNING -->|"TTC ≤ 3.0 s + 0.8 s warning"| L1
+    WARNING -->|"TTC ≤ 2.2 s + 0.8 s warning"| L2
+    WARNING -->|"TTC ≤ 1.8 s + 0.8 s warning"| L3
+    L1 -->|"TTC ≤ 2.2 s"| L2
+    L1 -->|"TTC ≤ 1.8 s"| L3
+    L1 -->|"TTC > 3.0 s for 200 ms"| WARNING
+    L1 -->|"vehicle speed = 0"| PB
+    L2 -->|"TTC ≤ 1.8 s"| L3
+    L2 -->|"TTC > 2.2 s for 200 ms"| L1
+    L2 -->|"vehicle speed = 0"| PB
+    L3 -->|"TTC > 1.8 s for 200 ms"| L2
+    L3 -->|"vehicle speed = 0"| PB
+    PB -->|"2.0 s elapsed"| STANDBY
+```
+
+**Floor distance** (prevent premature de-climbing while braking):
+- d ≤ 20 m → maintain minimum BRAKE_L1
+- d ≤ 10 m → maintain minimum BRAKE_L2
+- d ≤ 5 m → maintain minimum BRAKE_L3
+
+---
+
+### Intervention semantics
+
+- **WARNING** provides prior driver notification
+- **BRAKE_L1 / L2 / L3** represent progressively stronger autonomous braking
+- **POST_BRAKE** maintains brake hold after vehicle stop and manages post-stop release
+
+---
+
+## Validation Scenarios (Euro NCAP CCR)
+
+The requirements baseline defines representative validation scenarios and acceptance criteria:
+
+| Scenario | Condition | Acceptance Criterion |
+|---|---|---|
+| **CCRs** | Ego vehicle at 40 km/h, stationary target | Complete stop or residual speed < 5 km/h |
+| **CCRm** | Ego vehicle at 50 km/h, target at 20 km/h | Collision avoided or impact speed reduced by at least 20 km/h |
+| **CCRb** | Ego vehicle at 50 km/h, target decelerating at −2 m/s² | Collision avoided or impact speed < 15 km/h |
+
+In all validated scenarios, the project monitors final distance, residual speed, braking behaviour, and state transitions.
+
+---
+
+## Architecture
+
+The repository follows the classic **three-layer ADAS architecture**, in which perception provides validated input data, decision logic evaluates collision risk, and execution applies alerts and braking actions. In addition, **CAN** and **UDS** support communication and diagnostic functions across the system.
+
+| Block | Input | Processing | Output |
+|---|---|---|---|
+| **Perception** | Distance, ego speed, target speed, fault indicators | Validation, plausibility checks, signal conditioning | Trusted signals |
+| **Decision** | Trusted signals, override inputs | TTC, braking-floor logic, FSM transitions, risk assessment | Alert/braking request |
+| **Execution** | Alert/braking request | Alert generation and brake control | Brake command, alert output |
+| **CAN** | System signals | Communication transport and timeout handling | Encoded/decoded messages |
+| **UDS** | Diagnostic requests | Data access, DTC handling, enable/disable routines | Diagnostic responses |
+---
+
+## Software Decomposition
+
+The requirements-to-software traceability baseline maps the main functional domains to the following implementation modules:
+
+| Module | Responsibility |
+|---|---|
+| `aeb_perception.c` | sensor acquisition and validation |
+| `aeb_ttc.c` | TTC and braking-distance calculation |
+| `aeb_fsm.c` | risk classification, distance floors, and state-machine control |
+| `aeb_alert.c` | visual and audible alert outputs |
+| `aeb_pid.c` | braking control and brake-command generation |
+| `aeb_can.c` | CAN encoding, decoding, and timeout handling |
+| `aeb_uds.c` | UDS diagnostic services |
+
+This modular structure supports portability, maintainability, and bidirectional traceability.
+
+---
+## Compliance and Standards
+
+| Aspect | Standard | Status |
+|---|---|---|
+| Embedded C code | MISRA C:2012 | ✅ Implemented |
+| Functional safety | ISO 26262 ASIL-B | ✅ Compliant architecture |
+| Test scenarios | Euro NCAP AEB CCR v4.3 | ✅ CCRs, CCRm, CCRb |
+| AEB protocol | UNECE R152 | ✅ Alert ≥ 0.8 s before braking |
+| CAN bus | Proprietary DBC file | ✅ 5 structured frames |
+| Sensor fusion | ISO 15622 | ✅ Weighted radar + lidar |
+
+---
+## Authors
+- Eryca Francyele de Moura e Silva
+- Jéssica Roberta de Souza Santos
+- Lourenço Jamba Mphili
+- Renato Silva Fagundes
+- Rian Ithalo da Costa Linhares

--- a/include/aeb_alert.h
+++ b/include/aeb_alert.h
@@ -1,0 +1,57 @@
+/**
+ * @file    aeb_alert.h
+ * @brief   Alert mapping and driver override detection — public API.
+ * @owner   Task C (Jéssica Roberta de Souza Santos)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Maps FSM state to visual/audible alert outputs and detects
+ *          driver override via brake pedal or steering wheel input.
+ *
+ * @requirements FR-ALR-001 to FR-ALR-004, FR-DEC-006, FR-DEC-007
+ * @simulink     chart_79 (Alert_Map), chart_88 (Override_Det)
+ */
+
+#ifndef AEB_ALERT_H
+#define AEB_ALERT_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Map FSM state to alert output signals.
+ *
+ * Mapping table (from Simulink Alert_Map):
+ *   OFF / STANDBY    → ALERT_NONE,  BUZZER_SILENT
+ *   WARNING          → ALERT_BOTH,  BUZZER_SINGLE
+ *   BRAKE_L1         → ALERT_BOTH,  BUZZER_DOUBLE
+ *   BRAKE_L2         → ALERT_BOTH,  BUZZER_FAST_PULSE
+ *   BRAKE_L3         → ALERT_BOTH,  BUZZER_CONTINUOUS
+ *   POST_BRAKE       → ALERT_NONE,  BUZZER_SILENT
+ *
+ * @param[in]  fsm_state  Current FSM state (fsm_state_e).
+ * @param[out] output     Pointer to alert output struct.
+ *
+ * @requirement FR-ALR-001, FR-ALR-002, FR-ALR-004
+ */
+void alert_map(uint8_t fsm_state, alert_output_t *output);
+
+/**
+ * @brief Detect driver override condition.
+ *
+ * Override is active when:
+ *   - brake_pedal != 0, OR
+ *   - |steering_angle| > STEERING_OVERRIDE_DEG (5 degrees)
+ *
+ * @note In POST_BRAKE state, only accelerator pedal triggers override
+ *       (FR-FSM-006). This function handles the general case; the FSM
+ *       module applies the POST_BRAKE exception.
+ *
+ * @param[in] steering_angle  Steering wheel angle [degrees].
+ * @param[in] brake_pedal     Brake pedal status: 0=released, 1=pressed.
+ * @return    1 if override detected, 0 otherwise.
+ *
+ * @requirement FR-DEC-006, FR-DEC-007
+ */
+uint8_t override_detect(float32_t steering_angle, uint8_t brake_pedal);
+
+#endif /* AEB_ALERT_H */

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -1,0 +1,103 @@
+/**
+ * @file    aeb_can.h
+ * @brief   CAN bus communication module — public API.
+ * @owner   Task D (Renato Silva Fagundes)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Handles CAN frame transmission, reception, encoding/decoding,
+ *          and timeout detection for the AEB system.
+ *
+ * @requirements FR-CAN-001 to FR-CAN-004
+ * @simulink     system_177 (CAN_Bus subsystem)
+ */
+
+#ifndef AEB_CAN_H
+#define AEB_CAN_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Initialise CAN driver and register RX filters.
+ *
+ * Configures Zephyr CAN peripheral at CAN_BAUD_RATE (500 kbit/s),
+ * registers RX filters for radar target messages, and sets up TX work queue.
+ *
+ * @return 0 on success, negative error code on failure.
+ *
+ * @requirement FR-CAN-004
+ */
+int32_t can_init(void);
+
+/**
+ * @brief Transmit ego vehicle dynamics CAN frame.
+ *
+ * Encodes and transmits ego speed, FSM state, and brake command
+ * every CAN_TX_PERIOD_MS (50 ms).
+ *
+ * @param[in] fsm_out  Pointer to current FSM output.
+ * @param[in] pid_out  Pointer to current PID output.
+ *
+ * @requirement FR-CAN-001
+ */
+void can_tx_ego_dynamics(const fsm_output_t *fsm_out,
+                         const pid_output_t *pid_out);
+
+/**
+ * @brief Process received radar CAN frame (ISR-safe callback).
+ *
+ * Decodes relative distance and relative speed from incoming
+ * radar frame and pushes to ring buffer.
+ *
+ * @param[in] frame_data  Pointer to raw CAN frame data (8 bytes).
+ * @param[in] dlc         Data Length Code of received frame.
+ *
+ * @requirement FR-CAN-002, FR-CAN-003
+ */
+void can_rx_radar_callback(const uint8_t *frame_data, uint8_t dlc);
+
+/**
+ * @brief Check for CAN RX timeout.
+ *
+ * If 3 consecutive radar frames are missed (>= CAN_RX_TIMEOUT_MS),
+ * sets timeout fault flag.
+ *
+ * @return 1 if timeout detected, 0 otherwise.
+ *
+ * @requirement FR-CAN-002 (implicit timeout)
+ */
+uint8_t can_check_timeout(void);
+
+/**
+ * @brief Encode a signal into CAN frame data per DBC layout.
+ *
+ * @param[out] frame_data   Pointer to 8-byte frame buffer.
+ * @param[in]  raw_value    Signal value to encode.
+ * @param[in]  start_bit    Start bit position in frame.
+ * @param[in]  length       Signal bit length.
+ * @param[in]  scale        Signal scaling factor.
+ * @param[in]  offset       Signal offset.
+ *
+ * @requirement FR-CAN-003
+ */
+void can_encode_signal(uint8_t *frame_data, float32_t raw_value,
+                       uint8_t start_bit, uint8_t length,
+                       float32_t scale, float32_t offset);
+
+/**
+ * @brief Decode a signal from CAN frame data per DBC layout.
+ *
+ * @param[in]  frame_data  Pointer to 8-byte frame buffer.
+ * @param[in]  start_bit   Start bit position in frame.
+ * @param[in]  length      Signal bit length.
+ * @param[in]  scale       Signal scaling factor.
+ * @param[in]  offset      Signal offset.
+ * @return     Decoded physical signal value.
+ *
+ * @requirement FR-CAN-003
+ */
+float32_t can_decode_signal(const uint8_t *frame_data,
+                            uint8_t start_bit, uint8_t length,
+                            float32_t scale, float32_t offset);
+
+#endif /* AEB_CAN_H */

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -1,0 +1,220 @@
+/**
+ * @file    aeb_config.h
+ * @brief   Calibration parameters and system constants for the AEB system.
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details This file centralises all tuneable parameters used across the AEB
+ *          modules. Separating calibration from source code facilitates
+ *          maintenance and future system tuning without modifying functional
+ *          logic (NFR-POR-002).
+ *
+ *          Parameter values are derived from:
+ *          - SRS v2.0 (March 2026): Tables 4-18
+ *          - AEB_Tasks v1.0 (April 2026): Sections 3.2, 4.1-4.5
+ *          - Simulink model AEB_Integration.slx: validated parameters
+ *
+ * @requirements
+ *  - NFR-POR-002: Calibration parameters separated from code.
+ *  - NFR-COD-005: Fixed-width types used throughout.
+ *  - FR-COD-001:  Structural correspondence with Simulink model.
+ *
+ * @standard MISRA C:2012 compliant.
+ */
+
+#ifndef AEB_CONFIG_H
+#define AEB_CONFIG_H
+
+/* ========================================================================= */
+/*  Timing — NFR-PERF-001, NFR-PERF-002                                     */
+/* ========================================================================= */
+
+/** @brief AEB algorithm execution cycle period [ms].
+ *  @requirement NFR-PERF-001: 10 ms (100 Hz) execution cycle. */
+#define AEB_CYCLE_TIME_MS       10U
+
+/** @brief Execution cycle period in seconds [s].
+ *  @note Used in integration and filter calculations. */
+#define AEB_DT                  0.01f
+
+/* ========================================================================= */
+/*  TTC Thresholds — FR-DEC-004, Table 10 (SRS)                             */
+/* ========================================================================= */
+
+/** @brief TTC threshold for WARNING state entry [s].
+ *  @requirement FR-DEC-004: TTC <= 4.0 s triggers warning. */
+#define TTC_WARNING             4.0f
+
+/** @brief TTC threshold for BRAKE_L1 state entry [s].
+ *  @requirement FR-DEC-004: TTC <= 3.0 s triggers light pre-braking. */
+#define TTC_BRAKE_L1            3.0f
+
+/** @brief TTC threshold for BRAKE_L2 state entry [s].
+ *  @requirement FR-DEC-004: TTC <= 2.2 s triggers partial braking. */
+#define TTC_BRAKE_L2            2.2f
+
+/** @brief TTC threshold for BRAKE_L3 state entry [s].
+ *  @requirement FR-DEC-004: TTC <= 1.8 s triggers full emergency braking. */
+#define TTC_BRAKE_L3            1.8f
+
+/** @brief TTC saturation upper limit [s].
+ *  @note TTC is clamped to [0, TTC_MAX] to prevent unbounded values. */
+#define TTC_MAX                 10.0f
+
+/** @brief Minimum relative velocity for valid TTC calculation [m/s].
+ *  @requirement FR-DEC-001: TTC valid only when ego is approaching target. */
+#define V_REL_MIN               0.5f
+
+/* ========================================================================= */
+/*  Distance Floors — Table 10 (SRS), FR-DEC-003                            */
+/* ========================================================================= */
+
+/** @brief Distance floor for BRAKE_L1: do not de-escalate below L1
+ *         when distance <= 20 m [m]. */
+#define D_FLOOR_L1              20.0f
+
+/** @brief Distance floor for BRAKE_L2: do not de-escalate below L2
+ *         when distance <= 10 m [m]. */
+#define D_FLOOR_L2              10.0f
+
+/** @brief Distance floor for BRAKE_L3: do not de-escalate below L3
+ *         when distance <= 5 m [m]. */
+#define D_FLOOR_L3              5.0f
+
+/* ========================================================================= */
+/*  Speed Range — FR-DEC-008                                                 */
+/* ========================================================================= */
+
+/** @brief Minimum ego speed for AEB activation [m/s].
+ *  @note 2.78 m/s = 10 km/h.
+ *  @requirement FR-DEC-008: System active only when v_ego >= 10 km/h. */
+#define V_EGO_MIN               2.78f
+
+/** @brief Maximum ego speed for AEB activation [m/s].
+ *  @note 16.67 m/s = 60 km/h.
+ *  @requirement FR-DEC-008: System active only when v_ego <= 60 km/h. */
+#define V_EGO_MAX               16.67f
+
+/* ========================================================================= */
+/*  Deceleration Levels — Table 10 (SRS), FR-BRK-003                        */
+/* ========================================================================= */
+
+/** @brief Target deceleration for BRAKE_L1 [m/s^2].
+ *  @requirement Table 10: Light pre-braking at 2 m/s^2. */
+#define DECEL_L1                2.0f
+
+/** @brief Target deceleration for BRAKE_L2 [m/s^2].
+ *  @requirement Table 10: Partial braking at 4 m/s^2. */
+#define DECEL_L2                4.0f
+
+/** @brief Target deceleration for BRAKE_L3 [m/s^2].
+ *  @requirement Table 10: Full emergency braking at 6 m/s^2.
+ *  @note Also used as amax in d_brake calculation (FR-DEC-002). */
+#define DECEL_L3                6.0f
+
+/* ========================================================================= */
+/*  Hysteresis and Timing — FR-DEC-010, FR-ALR-003, FR-BRK-005              */
+/* ========================================================================= */
+
+/** @brief Minimum de-escalation debounce time [s].
+ *  @requirement FR-DEC-010: Hysteresis >= 200 ms to prevent chattering. */
+#define HYSTERESIS_TIME         0.2f
+
+/** @brief Minimum time in WARNING state before braking [s].
+ *  @requirement FR-ALR-003: Alert precedes braking by >= 800 ms. */
+#define WARNING_MIN_TIME        0.8f
+
+/** @brief Post-brake hold time after full stop [s].
+ *  @requirement FR-BRK-005: Maintain braking for >= 2.0 s after stop. */
+#define POST_BRAKE_HOLD         2.0f
+
+/** @brief Velocity threshold for complete vehicle stop [m/s].
+ *  @requirement FR-BRK-005: v_ego < 0.01 m/s considered full stop. */
+#define V_STOP_THRESHOLD        0.01f
+
+/* ========================================================================= */
+/*  PI Controller — FR-BRK-002, FR-BRK-004, FR-BRK-007                     */
+/* ========================================================================= */
+
+/** @brief Proportional gain for PI brake controller.
+ *  @requirement FR-BRK-002: PI controller with anti-windup. */
+#define PID_KP                  10.0f
+
+/** @brief Integral gain for PI brake controller.
+ *  @requirement FR-BRK-002: PI controller with anti-windup. */
+#define PID_KI                  0.05f
+
+/** @brief Maximum integrator accumulation [%].
+ *  @note Anti-windup clamp for integral term. */
+#define PID_INTEG_MAX           50.0f
+
+/** @brief Maximum brake command output [%].
+ *  @requirement FR-BRK-007: Output clamped to [0, 100] %. */
+#define BRAKE_OUT_MAX           100.0f
+
+/** @brief Minimum brake command output [%].
+ *  @requirement FR-BRK-007: Output clamped to [0, 100] %. */
+#define BRAKE_OUT_MIN           0.0f
+
+/** @brief Maximum longitudinal jerk [m/s^3].
+ *  @requirement FR-BRK-004: |jerk| <= 10 m/s^3 in all scenarios. */
+#define MAX_JERK                10.0f
+
+/* ========================================================================= */
+/*  Sensor Fault Detection — FR-PER-006, FR-PER-007                         */
+/* ========================================================================= */
+
+/** @brief Consecutive invalid cycles to trigger sensor fault latch.
+ *  @requirement FR-PER-007: Fault detected within 3 cycles (30 ms). */
+#define SENSOR_FAULT_CYCLES     3U
+
+/** @brief Maximum allowed rate-of-change for distance per cycle [m/cycle].
+ *  @requirement FR-PER-006: Rate-of-change validation. */
+#define DIST_ROC_LIMIT          10.0f
+
+/** @brief Maximum allowed rate-of-change for velocity per cycle [m/s/cycle].
+ *  @requirement FR-PER-006: Rate-of-change validation. */
+#define VEL_ROC_LIMIT           2.0f
+
+/** @brief Steering angle threshold for driver override [degrees].
+ *  @requirement FR-DEC-007: Override if steering angle > 5 degrees. */
+#define STEERING_OVERRIDE_DEG   5.0f
+
+/* ========================================================================= */
+/*  CAN Bus — FR-CAN-001 to FR-CAN-004                                      */
+/* ========================================================================= */
+
+/** @brief CAN bus baud rate [bit/s].
+ *  @requirement FR-CAN-004: Network operates at 500 kbit/s. */
+#define CAN_BAUD_RATE           500000U
+
+/** @brief CAN TX period for ego vehicle dynamics [ms].
+ *  @requirement FR-CAN-001: Ego dynamics transmitted every 50 ms. */
+#define CAN_TX_PERIOD_MS        50U
+
+/** @brief CAN RX timeout threshold [ms].
+ *  @note 3 consecutive missed frames at 20 ms period = 60 ms.
+ *  @requirement FR-CAN-002: Radar target data expected every 20 ms. */
+#define CAN_RX_TIMEOUT_MS       60U
+
+/* ========================================================================= */
+/*  UDS Diagnostics — FR-UDS-001 to FR-UDS-005                              */
+/* ========================================================================= */
+
+/** @brief UDS DID for TTC value (scaled: TTC x 100).
+ *  @requirement FR-UDS-001: ReadDataByIdentifier for TTC. */
+#define UDS_DID_TTC             0xF100U
+
+/** @brief UDS DID for FSM state value.
+ *  @requirement FR-UDS-001: ReadDataByIdentifier for FSM state. */
+#define UDS_DID_FSM_STATE       0xF101U
+
+/** @brief UDS DID for brake pressure value (scaled: pressure x 10).
+ *  @requirement FR-UDS-001: ReadDataByIdentifier for brake pressure. */
+#define UDS_DID_BRAKE_PRESS     0xF102U
+
+/** @brief UDS Routine ID for AEB enable/disable control.
+ *  @requirement FR-UDS-004: RoutineControl with routine 0x0301. */
+#define UDS_ROUTINE_AEB         0x0301U
+
+#endif /* AEB_CONFIG_H */

--- a/include/aeb_fsm.h
+++ b/include/aeb_fsm.h
@@ -1,0 +1,53 @@
+/**
+ * @file    aeb_fsm.h
+ * @brief   Finite State Machine module — public API.
+ * @owner   Task B (Lourenço Jamba Mphili)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Implements the 7-state FSM controlling AEB intervention levels
+ *          with hysteresis, distance floors, and driver override logic.
+ *
+ * @requirements FR-DEC-004 to FR-DEC-011, FR-FSM-001 to FR-FSM-006
+ * @simulink     chart_58 (FSM_Logic)
+ */
+
+#ifndef AEB_FSM_H
+#define AEB_FSM_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Initialise FSM internal state.
+ *
+ * Sets initial state to FSM_OFF, clears all timers and flags.
+ * Must be called once at system startup.
+ */
+void fsm_init(void);
+
+/**
+ * @brief Execute one FSM step.
+ *
+ * Evaluates state transitions based on TTC output, perception data,
+ * and driver inputs. Applies priority logic:
+ *   (i)   Fault → OFF
+ *   (ii)  AEB disabled → OFF
+ *   (iii) Speed out of range → STANDBY (with exceptions)
+ *   (iv)  Driver override → STANDBY
+ *   (v)   Threat evaluation via TTC + distance floors
+ *   (vi)  Escalation immediate; de-escalation with 200 ms debounce
+ *   (vii) POST_BRAKE: hold 2.0 s or accelerator override
+ *
+ * @param[in]  ttc_in     Pointer to TTC calculation output.
+ * @param[in]  percep_in  Pointer to perception output.
+ * @param[in]  driver_in  Pointer to driver input signals.
+ * @param[out] output     Pointer to FSM output struct.
+ *
+ * @requirement FR-FSM-001 to FR-FSM-006, FR-DEC-004 to FR-DEC-011
+ */
+void fsm_step(const ttc_output_t *ttc_in,
+              const perception_output_t *percep_in,
+              const driver_input_t *driver_in,
+              fsm_output_t *output);
+
+#endif /* AEB_FSM_H */

--- a/include/aeb_perception.h
+++ b/include/aeb_perception.h
@@ -1,0 +1,105 @@
+/**
+ * @file    aeb_perception.h
+ * @brief   Perception and sensor fusion module — public API.
+ * @owner   Task A (Eryca Francyele de Moura e Silva)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Provides sensor fault detection (radar, lidar) and Kalman-based
+ *          fusion of distance and relative velocity measurements.
+ *
+ * @requirements FR-PER-001 to FR-PER-008
+ * @simulink     chart_26 (LidarFault), chart_33 (RadarFault),
+ *               chart_41 (KalmanFusion)
+ */
+
+#ifndef AEB_PERCEPTION_H
+#define AEB_PERCEPTION_H
+
+#include "aeb_types.h"
+
+/* ========================================================================= */
+/*  Public function prototypes                                               */
+/* ========================================================================= */
+
+/**
+ * @brief Initialise perception module internal state.
+ *
+ * Resets Kalman filter state, fault counters, and previous-cycle values.
+ * Must be called once at system startup before the first cycle.
+ */
+void perception_init(void);
+
+/**
+ * @brief Detect radar sensor fault via plausibility checks.
+ *
+ * Validates range [0.5, 200] m, relative velocity |vr| <= 50 m/s,
+ * and rate-of-change limits. Latches fault after SENSOR_FAULT_CYCLES
+ * consecutive invalid readings.
+ *
+ * @param[in] d_radar   Radar distance measurement [m].
+ * @param[in] vr_radar  Radar relative velocity measurement [m/s].
+ * @return    1 if fault detected (latched), 0 otherwise.
+ *
+ * @requirement FR-PER-006, FR-PER-007
+ */
+uint8_t radar_fault_detect(float32_t d_radar, float32_t vr_radar);
+
+/**
+ * @brief Detect lidar sensor fault via plausibility checks.
+ *
+ * Validates range [1, 100] m and rate-of-change limits.
+ * Latches fault after SENSOR_FAULT_CYCLES consecutive invalid readings.
+ *
+ * @param[in] d_lidar  Lidar distance measurement [m].
+ * @return    1 if fault detected (latched), 0 otherwise.
+ *
+ * @requirement FR-PER-006, FR-PER-007
+ */
+uint8_t lidar_fault_detect(float32_t d_lidar);
+
+/**
+ * @brief Kalman fusion of radar and lidar measurements.
+ *
+ * Discrete 1D Kalman filter with state x = [distance, v_rel]^T.
+ * Sequential update: LiDAR first (H=[1,0], R=0.0025), then
+ * Radar (H=I2, R=diag(0.09, 0.01)).
+ *
+ * Confidence based on sensor availability:
+ * both=1.0, radar-only=0.7, lidar-only=0.5, scaled by trace(P).
+ *
+ * @param[in]  d_radar       Radar distance [m].
+ * @param[in]  vr_radar      Radar relative velocity [m/s].
+ * @param[in]  d_lidar       Lidar distance [m].
+ * @param[in]  v_ego         Ego vehicle speed [m/s].
+ * @param[in]  radar_valid   1 if radar data is valid, 0 otherwise.
+ * @param[in]  lidar_valid   1 if lidar data is valid, 0 otherwise.
+ * @param[out] output        Pointer to perception output struct.
+ *
+ * @requirement FR-PER-001, FR-PER-002, FR-PER-003
+ */
+void kalman_fusion(float32_t d_radar, float32_t vr_radar,
+                   float32_t d_lidar, float32_t v_ego,
+                   uint8_t radar_valid, uint8_t lidar_valid,
+                   perception_output_t *output);
+
+/**
+ * @brief Execute one full perception cycle.
+ *
+ * Top-level function called every 10 ms. Runs fault detection
+ * on both sensors, then Kalman fusion, producing a complete
+ * perception_output_t.
+ *
+ * @param[in]  d_radar   Raw radar distance [m].
+ * @param[in]  vr_radar  Raw radar relative velocity [m/s].
+ * @param[in]  d_lidar   Raw lidar distance [m].
+ * @param[in]  v_ego     Ego vehicle speed [m/s].
+ * @param[out] output    Pointer to perception output struct.
+ *
+ * @requirement FR-PER-001 to FR-PER-008
+ */
+void perception_step(float32_t d_radar, float32_t vr_radar,
+                     float32_t d_lidar, float32_t v_ego,
+                     perception_output_t *output);
+
+#endif /* AEB_PERCEPTION_H */

--- a/include/aeb_pid.h
+++ b/include/aeb_pid.h
@@ -1,0 +1,50 @@
+/**
+ * @file    aeb_pid.h
+ * @brief   PI brake controller module — public API.
+ * @owner   Task C (Jéssica Roberta de Souza Santos)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Implements a PI controller with anti-windup and jerk limiting
+ *          to generate smooth brake commands based on FSM deceleration targets.
+ *
+ * @requirements FR-BRK-001 to FR-BRK-007
+ * @simulink     chart_96 (PID_Logic)
+ */
+
+#ifndef AEB_PID_H
+#define AEB_PID_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Initialise PID controller internal state.
+ *
+ * Resets integrator accumulator, previous output, and internal flags.
+ * Must be called once at system startup.
+ */
+void pid_init(void);
+
+/**
+ * @brief Execute one PI brake controller step.
+ *
+ * Computes brake command using PI control law:
+ *   error = decel_target - a_ego
+ *   integral += Ki * error * dt  (clamped to [0, PID_INTEG_MAX])
+ *   output = Kp * error + integral
+ *   output clamped to [0, 100] %
+ *   jerk limited: |delta_output| <= MAX_JERK * (100/DECEL_L3) * dt
+ *
+ * Controller resets when decel_target <= 0 or fsm_state < FSM_BRAKE_L1.
+ *
+ * @param[in]  decel_target  Target deceleration from FSM [m/s^2].
+ * @param[in]  a_ego         Current ego vehicle deceleration [m/s^2].
+ * @param[in]  fsm_state     Current FSM state (fsm_state_e).
+ * @param[out] output        Pointer to PID output struct.
+ *
+ * @requirement FR-BRK-001 to FR-BRK-007
+ */
+void pid_brake_step(float32_t decel_target, float32_t a_ego,
+                    uint8_t fsm_state, pid_output_t *output);
+
+#endif /* AEB_PID_H */

--- a/include/aeb_ttc.h
+++ b/include/aeb_ttc.h
@@ -1,0 +1,38 @@
+/**
+ * @file    aeb_ttc.h
+ * @brief   TTC and braking distance calculation module — public API.
+ * @owner   Task B (Lourenço Jamba Mphili)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Computes Time-To-Collision and minimum braking distance
+ *          using the dual criterion defined in the SRS.
+ *
+ * @requirements FR-DEC-001, FR-DEC-002, FR-DEC-003
+ * @simulink     chart_106 (TTC_Logic)
+ */
+
+#ifndef AEB_TTC_H
+#define AEB_TTC_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Compute TTC, braking distance, and closing condition.
+ *
+ * TTC = d / v_rel  when v_rel > V_REL_MIN (0.5 m/s), else TTC = TTC_MAX.
+ * d_brake = v_ego^2 / (2 * DECEL_L3).
+ * TTC clamped to [0, TTC_MAX].
+ * is_closing set when v_rel > 0.
+ *
+ * @param[in]  distance  Relative distance to target [m].
+ * @param[in]  v_ego     Ego vehicle speed [m/s].
+ * @param[in]  v_target  Target vehicle speed [m/s].
+ * @param[out] output    Pointer to TTC output struct.
+ *
+ * @requirement FR-DEC-001, FR-DEC-002
+ */
+void ttc_calc(float32_t distance, float32_t v_ego,
+              float32_t v_target, ttc_output_t *output);
+
+#endif /* AEB_TTC_H */

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -1,0 +1,182 @@
+/**
+ * @file    aeb_types.h
+ * @brief   Shared data structures and enumerations for the AEB system.
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details This file defines the typed interface contract between all AEB
+ *          modules. Every module communicates exclusively through these
+ *          structs, passed by pointer. No global mutable state is shared
+ *          outside of Zephyr kernel objects (mutexes, timers).
+ *
+ * @note    All types use fixed-width definitions per NFR-COD-005.
+ *          This file shall be reviewed and agreed upon by the entire team
+ *          before individual module development begins (Sprint 0).
+ *
+ * @requirements
+ *  - NFR-COD-005: Exclusive use of fixed-width types.
+ *  - NFR-POR-003: Modular architecture with well-defined interfaces.
+ *  - FR-COD-001:  Structural correspondence between Simulink model
+ *                 and C implementation.
+ *
+ * @standard MISRA C:2012 compliant.
+ */
+
+#ifndef AEB_TYPES_H
+#define AEB_TYPES_H
+
+/* ========================================================================= */
+/*  Standard includes                                                        */
+/* ========================================================================= */
+#include <stdint.h>
+
+/* ========================================================================= */
+/*  Fixed-width float alias (NFR-COD-005)                                    */
+/* ========================================================================= */
+
+/** @brief 32-bit floating-point type alias for cross-platform portability. */
+typedef float float32_t;
+
+/* ========================================================================= */
+/*  Enumerations                                                             */
+/* ========================================================================= */
+
+/**
+ * @brief FSM state enumeration.
+ *
+ * Defines the seven operational states of the AEB Finite State Machine
+ * as specified in FR-FSM-001 and Table 10 of the SRS v2.0.
+ *
+ * State transitions follow the rules defined in FR-FSM-002 to FR-FSM-006.
+ *
+ * @requirement FR-FSM-001
+ */
+typedef enum {
+    FSM_OFF        = 0,  /**< System disabled (AEB switch off or fault). */
+    FSM_STANDBY    = 1,  /**< System active, no threat detected.        */
+    FSM_WARNING    = 2,  /**< Visual + audible alert, TTC <= 4.0 s.     */
+    FSM_BRAKE_L1   = 3,  /**< Light pre-braking, 2 m/s^2.              */
+    FSM_BRAKE_L2   = 4,  /**< Partial braking, 4 m/s^2.                */
+    FSM_BRAKE_L3   = 5,  /**< Full emergency braking, 6 m/s^2.         */
+    FSM_POST_BRAKE = 6   /**< Brake hold after full stop (2 s).         */
+} fsm_state_e;
+
+/**
+ * @brief Alert type enumeration.
+ *
+ * Defines the alert output modes used by the alert_map() function.
+ *
+ * @requirement FR-ALR-001, FR-ALR-002
+ */
+typedef enum {
+    ALERT_NONE    = 0,  /**< No alert active.                           */
+    ALERT_VISUAL  = 1,  /**< Visual alert only (dashboard indicator).   */
+    ALERT_AUDIBLE = 2,  /**< Audible alert only (buzzer/beep).          */
+    ALERT_BOTH    = 3   /**< Visual + audible alert.                    */
+} alert_type_e;
+
+/**
+ * @brief Buzzer command enumeration.
+ *
+ * Defines the buzzer patterns mapped from FSM states
+ * as specified in AEB_Tasks Section 4.3 (Alert_Map table).
+ */
+typedef enum {
+    BUZZER_SILENT     = 0,  /**< No sound — OFF / STANDBY / POST_BRAKE. */
+    BUZZER_SINGLE     = 1,  /**< Single beep — WARNING state.           */
+    BUZZER_DOUBLE     = 2,  /**< Double beep — BRAKE_L1 state.          */
+    BUZZER_CONTINUOUS = 3,  /**< Continuous beep — BRAKE_L3 state.      */
+    BUZZER_FAST_PULSE = 4   /**< Fast pulse — BRAKE_L2 state.           */
+} buzzer_cmd_e;
+
+/* ========================================================================= */
+/*  Data structures — Inter-module interface contracts                       */
+/* ========================================================================= */
+
+/**
+ * @brief Perception module output (Task A -> Task B).
+ *
+ * Contains validated and fused sensor data produced by the perception
+ * module after Kalman fusion and fault detection.
+ *
+ * @requirement FR-PER-001 to FR-PER-008
+ */
+typedef struct {
+    float32_t distance;    /**< Fused relative distance [0, 300] m.         */
+    float32_t v_ego;       /**< Ego vehicle speed [m/s].                    */
+    float32_t v_rel;       /**< Relative velocity [m/s] (>0 = closing).     */
+    float32_t confidence;  /**< Fusion confidence [0.0, 1.0].               */
+    uint8_t   fault_flag;  /**< Sensor fault indicator: 0=OK, 1=fault.      */
+} perception_output_t;
+
+/**
+ * @brief TTC calculation output (Task B internal).
+ *
+ * Contains the Time-To-Collision, minimum braking distance, and
+ * approach condition flag.
+ *
+ * @requirement FR-DEC-001, FR-DEC-002, FR-DEC-003
+ */
+typedef struct {
+    float32_t ttc;         /**< Time-To-Collision [0, 10] s.                */
+    float32_t d_brake;     /**< Minimum braking distance [m].               */
+    uint8_t   is_closing;  /**< Approach condition: 1 if v_rel > 0.         */
+} ttc_output_t;
+
+/**
+ * @brief FSM output (Task B -> Tasks C, D, E).
+ *
+ * Contains the current state machine output including target
+ * deceleration, brake activation flag, alert level, and internal timers.
+ *
+ * @requirement FR-FSM-001 to FR-FSM-006, FR-DEC-004 to FR-DEC-011
+ */
+typedef struct {
+    uint8_t   fsm_state;     /**< Current FSM state (fsm_state_e).          */
+    float32_t decel_target;  /**< Target deceleration [m/s^2].              */
+    uint8_t   brake_active;  /**< Brake actuation flag: 0=off, 1=on.        */
+    uint8_t   alert_level;   /**< Alert severity: 0=none .. 3=critical.     */
+    float32_t warn_timer;    /**< Time elapsed in WARNING state [s].         */
+    float32_t state_timer;   /**< Time elapsed in current state [s].         */
+} fsm_output_t;
+
+/**
+ * @brief PID brake controller output (Task C -> Task D TX).
+ *
+ * Contains the computed brake command as percentage and pressure.
+ *
+ * @requirement FR-BRK-001 to FR-BRK-007
+ */
+typedef struct {
+    float32_t brake_pct;   /**< Brake command [0, 100] %.                   */
+    float32_t brake_bar;   /**< Brake pressure [0, 10] bar.                 */
+} pid_output_t;
+
+/**
+ * @brief Alert output (Task C -> GPIO).
+ *
+ * Contains the alert signals to be output via GPIO to the HMI.
+ *
+ * @requirement FR-ALR-001 to FR-ALR-004
+ */
+typedef struct {
+    uint8_t   alert_type;    /**< Alert type (alert_type_e).                */
+    uint8_t   alert_active;  /**< Alert active flag: 0=off, 1=on.           */
+    uint8_t   buzzer_cmd;    /**< Buzzer pattern (buzzer_cmd_e).            */
+} alert_output_t;
+
+/**
+ * @brief Driver input signals (Task D RX -> Tasks B, C).
+ *
+ * Contains driver interaction signals decoded from CAN bus.
+ *
+ * @requirement FR-PER-004, FR-PER-005, FR-PER-008, FR-DEC-006, FR-DEC-007
+ */
+typedef struct {
+    uint8_t   brake_pedal;     /**< Brake pedal pressed: 0=no, 1=yes.       */
+    uint8_t   accel_pedal;     /**< Accelerator pedal pressed: 0=no, 1=yes. */
+    float32_t steering_angle;  /**< Steering wheel angle [degrees].         */
+    uint8_t   aeb_enabled;     /**< AEB function enabled: 0=no, 1=yes.      */
+} driver_input_t;
+
+#endif /* AEB_TYPES_H */

--- a/include/aeb_uds.h
+++ b/include/aeb_uds.h
@@ -1,0 +1,91 @@
+/**
+ * @file    aeb_uds.h
+ * @brief   UDS diagnostics services module — public API.
+ * @owner   Task E (Rian Ithalo da Costa Linhares)
+ * @version 1.0
+ * @date    2026-04-08
+ *
+ * @details Implements ISO 14229 UDS services: ReadDataByIdentifier,
+ *          ClearDiagnosticInformation, RoutineControl, and DTC monitoring.
+ *
+ * @requirements FR-UDS-001 to FR-UDS-005
+ * @simulink     chart_117 (UDS_Server)
+ */
+
+#ifndef AEB_UDS_H
+#define AEB_UDS_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Initialise UDS module.
+ *
+ * Clears all stored DTCs and resets internal state.
+ */
+void uds_init(void);
+
+/**
+ * @brief Process an incoming UDS diagnostic request.
+ *
+ * Dispatches based on SID:
+ *   SID 0x22: ReadDataByIdentifier (TTC, FSM state, brake pressure)
+ *   SID 0x14: ClearDiagnosticInformation (reset all DTCs)
+ *   SID 0x31: RoutineControl (enable/disable AEB, routine 0x0301)
+ *   Other:    Negative response 0x7F
+ *
+ * @param[in]  sid       Service Identifier.
+ * @param[in]  did_high  DID high byte (for SID 0x22).
+ * @param[in]  did_low   DID low byte (for SID 0x22).
+ * @param[in]  value     Input value (for SID 0x31 routine parameter).
+ * @param[out] response  Pointer to response buffer (8 bytes minimum).
+ * @param[out] resp_len  Pointer to response length.
+ *
+ * @requirement FR-UDS-001 to FR-UDS-005
+ */
+void uds_process_request(uint8_t sid, uint8_t did_high, uint8_t did_low,
+                         uint8_t value, uint8_t *response, uint8_t *resp_len);
+
+/**
+ * @brief Monitor fault conditions and update DTC storage.
+ *
+ * Checks for:
+ *   C1001: sensor fault
+ *   C1004: CRC error
+ *   C1006: actuator fault
+ *
+ * DTCs are latched until cleared by SID 0x14.
+ * Fault lamp activated when dtc_count > 0.
+ *
+ * @param[in] sensor_fault    Sensor fault flag (from perception).
+ * @param[in] crc_error       CRC error flag (from CAN).
+ * @param[in] actuator_fault  Actuator fault flag.
+ * @return    Number of active DTCs.
+ *
+ * @requirement FR-UDS-002
+ */
+uint8_t uds_monitor_faults(uint8_t sensor_fault, uint8_t crc_error,
+                           uint8_t actuator_fault);
+
+/**
+ * @brief Get the current AEB enable state set via UDS.
+ *
+ * @return 1 if AEB is enabled, 0 if disabled via RoutineControl.
+ *
+ * @requirement FR-UDS-004
+ */
+uint8_t uds_get_aeb_enabled(void);
+
+/**
+ * @brief Update live diagnostic data for ReadDataByIdentifier.
+ *
+ * Called each cycle to refresh the values returned by SID 0x22.
+ *
+ * @param[in] fsm_out  Pointer to current FSM output.
+ * @param[in] ttc_out  Pointer to current TTC output.
+ * @param[in] pid_out  Pointer to current PID output.
+ */
+void uds_update_live_data(const fsm_output_t *fsm_out,
+                          const ttc_output_t *ttc_out,
+                          const pid_output_t *pid_out);
+
+#endif /* AEB_UDS_H */

--- a/prj.conf
+++ b/prj.conf
@@ -1,0 +1,37 @@
+# ===========================================================================
+# prj.conf — Zephyr RTOS configuration for AEB System
+# ===========================================================================
+# This file enables the Zephyr subsystems required by the AEB application.
+# Adjust board-specific settings in boards/<board>.overlay.
+# ===========================================================================
+
+# --- Kernel and threading ---------------------------------------------------
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_HEAP_MEM_POOL_SIZE=0
+
+# Cooperative threads (no preemption within same priority)
+CONFIG_NUM_COOP_PRIORITIES=16
+CONFIG_NUM_PREEMPT_PRIORITIES=0
+
+# Timer for 10 ms periodic execution (NFR-PERF-001)
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+# --- CAN bus (FR-CAN-001 to FR-CAN-004) ------------------------------------
+CONFIG_CAN=y
+CONFIG_CAN_MAX_FILTER=8
+
+# --- GPIO (alert outputs: visual + audible) ---------------------------------
+CONFIG_GPIO=y
+
+# --- Logging (development only, disable for production) ---------------------
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=3
+CONFIG_LOG_BUFFER_SIZE=1024
+
+# --- Safety: no dynamic allocation (NFR-COD-002) ---------------------------
+CONFIG_HEAP_MEM_POOL_SIZE=0
+
+# --- Shell (optional, for debug during development) -------------------------
+# CONFIG_SHELL=y
+# CONFIG_SHELL_BACKEND_SERIAL=y

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -1,0 +1,63 @@
+/**
+ * @file    aeb_can.c
+ * @brief   CAN bus communication — STUB implementation (Sprint 0).
+ * @owner   Task D (Renato Silva Fagundes)
+ *
+ * @todo    Implement CAN init, TX, RX, timeout, encode/decode.
+ */
+
+#include "aeb_can.h"
+#include "aeb_config.h"
+
+int32_t can_init(void)
+{
+    /* STUB: success. */
+    return 0;
+}
+
+void can_tx_ego_dynamics(const fsm_output_t *fsm_out,
+                         const pid_output_t *pid_out)
+{
+    (void)fsm_out;
+    (void)pid_out;
+    /* STUB: no transmission. */
+}
+
+void can_rx_radar_callback(const uint8_t *frame_data, uint8_t dlc)
+{
+    (void)frame_data;
+    (void)dlc;
+    /* STUB: no processing. */
+}
+
+uint8_t can_check_timeout(void)
+{
+    /* STUB: no timeout. */
+    return 0U;
+}
+
+void can_encode_signal(uint8_t *frame_data, float32_t raw_value,
+                       uint8_t start_bit, uint8_t length,
+                       float32_t scale, float32_t offset)
+{
+    (void)frame_data;
+    (void)raw_value;
+    (void)start_bit;
+    (void)length;
+    (void)scale;
+    (void)offset;
+    /* STUB: no encoding. */
+}
+
+float32_t can_decode_signal(const uint8_t *frame_data,
+                            uint8_t start_bit, uint8_t length,
+                            float32_t scale, float32_t offset)
+{
+    (void)frame_data;
+    (void)start_bit;
+    (void)length;
+    (void)scale;
+    (void)offset;
+    /* STUB: return zero. */
+    return 0.0f;
+}

--- a/src/communication/aeb_uds.c
+++ b/src/communication/aeb_uds.c
@@ -1,0 +1,58 @@
+/**
+ * @file    aeb_uds.c
+ * @brief   UDS diagnostics — STUB implementation (Sprint 0).
+ * @owner   Task E (Rian Ithalo da Costa Linhares)
+ *
+ * @todo    Implement UDS request processing, DTC monitoring,
+ *          and live data management.
+ */
+
+#include "aeb_uds.h"
+#include "aeb_config.h"
+
+void uds_init(void)
+{
+    /* STUB: no internal state to initialise yet. */
+}
+
+void uds_process_request(uint8_t sid, uint8_t did_high, uint8_t did_low,
+                         uint8_t value, uint8_t *response, uint8_t *resp_len)
+{
+    (void)sid;
+    (void)did_high;
+    (void)did_low;
+    (void)value;
+
+    /* STUB: negative response (unsupported service). */
+    response[0] = 0x7FU;
+    response[1] = sid;
+    response[2] = 0x11U;  /* serviceNotSupported */
+    *resp_len   = 3U;
+}
+
+uint8_t uds_monitor_faults(uint8_t sensor_fault, uint8_t crc_error,
+                           uint8_t actuator_fault)
+{
+    (void)sensor_fault;
+    (void)crc_error;
+    (void)actuator_fault;
+
+    /* STUB: no faults. */
+    return 0U;
+}
+
+uint8_t uds_get_aeb_enabled(void)
+{
+    /* STUB: AEB enabled by default. */
+    return 1U;
+}
+
+void uds_update_live_data(const fsm_output_t *fsm_out,
+                          const ttc_output_t *ttc_out,
+                          const pid_output_t *pid_out)
+{
+    (void)fsm_out;
+    (void)ttc_out;
+    (void)pid_out;
+    /* STUB: no update. */
+}

--- a/src/decision/aeb_fsm.c
+++ b/src/decision/aeb_fsm.c
@@ -1,0 +1,33 @@
+/**
+ * @file    aeb_fsm.c
+ * @brief   FSM module — STUB implementation (Sprint 0).
+ * @owner   Task B (Lourenço Jamba Mphili)
+ *
+ * @todo    Implement fsm_step with full 7-state FSM logic.
+ */
+
+#include "aeb_fsm.h"
+#include "aeb_config.h"
+
+void fsm_init(void)
+{
+    /* STUB: no internal state to initialise yet. */
+}
+
+void fsm_step(const ttc_output_t *ttc_in,
+              const perception_output_t *percep_in,
+              const driver_input_t *driver_in,
+              fsm_output_t *output)
+{
+    (void)ttc_in;
+    (void)percep_in;
+    (void)driver_in;
+
+    /* STUB: safe default — system in STANDBY, no braking. */
+    output->fsm_state    = (uint8_t)FSM_STANDBY;
+    output->decel_target = 0.0f;
+    output->brake_active = 0U;
+    output->alert_level  = 0U;
+    output->warn_timer   = 0.0f;
+    output->state_timer  = 0.0f;
+}

--- a/src/decision/aeb_ttc.c
+++ b/src/decision/aeb_ttc.c
@@ -1,0 +1,23 @@
+/**
+ * @file    aeb_ttc.c
+ * @brief   TTC calculation module — STUB implementation (Sprint 0).
+ * @owner   Task B (Lourenço Jamba Mphili)
+ *
+ * @todo    Implement ttc_calc with full TTC and d_brake logic.
+ */
+
+#include "aeb_ttc.h"
+#include "aeb_config.h"
+
+void ttc_calc(float32_t distance, float32_t v_ego,
+              float32_t v_target, ttc_output_t *output)
+{
+    (void)distance;
+    (void)v_ego;
+    (void)v_target;
+
+    /* STUB: safe defaults — no threat. */
+    output->ttc        = TTC_MAX;
+    output->d_brake    = 0.0f;
+    output->is_closing = 0U;
+}

--- a/src/execution/aeb_alert.c
+++ b/src/execution/aeb_alert.c
@@ -1,0 +1,29 @@
+/**
+ * @file    aeb_alert.c
+ * @brief   Alert mapping and override detection — STUB implementation (Sprint 0).
+ * @owner   Task C (Jéssica Roberta de Souza Santos)
+ *
+ * @todo    Implement alert_map and override_detect with full logic.
+ */
+
+#include "aeb_alert.h"
+#include "aeb_config.h"
+
+void alert_map(uint8_t fsm_state, alert_output_t *output)
+{
+    (void)fsm_state;
+
+    /* STUB: safe default — no alert. */
+    output->alert_type   = (uint8_t)ALERT_NONE;
+    output->alert_active = 0U;
+    output->buzzer_cmd   = (uint8_t)BUZZER_SILENT;
+}
+
+uint8_t override_detect(float32_t steering_angle, uint8_t brake_pedal)
+{
+    (void)steering_angle;
+    (void)brake_pedal;
+
+    /* STUB: no override detected. */
+    return 0U;
+}

--- a/src/execution/aeb_pid.c
+++ b/src/execution/aeb_pid.c
@@ -1,0 +1,28 @@
+/**
+ * @file    aeb_pid.c
+ * @brief   PI brake controller — STUB implementation (Sprint 0).
+ * @owner   Task C (Jéssica Roberta de Souza Santos)
+ *
+ * @todo    Implement pid_brake_step with PI control, anti-windup,
+ *          and jerk limiting.
+ */
+
+#include "aeb_pid.h"
+#include "aeb_config.h"
+
+void pid_init(void)
+{
+    /* STUB: no internal state to initialise yet. */
+}
+
+void pid_brake_step(float32_t decel_target, float32_t a_ego,
+                    uint8_t fsm_state, pid_output_t *output)
+{
+    (void)decel_target;
+    (void)a_ego;
+    (void)fsm_state;
+
+    /* STUB: safe default — no braking. */
+    output->brake_pct = 0.0f;
+    output->brake_bar = 0.0f;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,52 @@
+/**
+ * @file    main.c
+ * @brief   AEB system entry point — STUB implementation (Sprint 0).
+ * @owner   Task E (Rian Ithalo da Costa Linhares)
+ *
+ * @details In the final implementation, this file will:
+ *          - Initialise all modules
+ *          - Configure Zephyr threads and k_timer (10 ms)
+ *          - Run the main execution cycle
+ *          - Manage mutexes for shared data
+ *
+ * @todo    Implement Zephyr threading model, timer, and integration.
+ */
+
+#include "aeb_types.h"
+#include "aeb_config.h"
+#include "aeb_perception.h"
+#include "aeb_ttc.h"
+#include "aeb_fsm.h"
+#include "aeb_pid.h"
+#include "aeb_alert.h"
+#include "aeb_can.h"
+#include "aeb_uds.h"
+
+/**
+ * @brief Application entry point.
+ *
+ * Initialises all AEB modules. In the full implementation,
+ * this will set up Zephyr threads and the 10 ms timer.
+ *
+ * @return 0 on success.
+ */
+int main(void)
+{
+    /* Initialise all modules */
+    perception_init();
+    fsm_init();
+    pid_init();
+    (void)can_init();
+    uds_init();
+
+    /*
+     * STUB: In full implementation, this will:
+     * 1. Create k_timer for 10 ms periodic execution
+     * 2. Create thread_perception (priority 1)
+     * 3. Create thread_controller (priority 2)
+     * 4. Create thread_communication (priority 3)
+     * 5. Enter Zephyr scheduler
+     */
+
+    return 0;
+}

--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -1,0 +1,65 @@
+/**
+ * @file    aeb_perception.c
+ * @brief   Perception module — STUB implementation (Sprint 0).
+ * @owner   Task A (Eryca Francyele de Moura e Silva)
+ *
+ * @details Stub functions return safe default values (zero/no-fault).
+ *          Replace with full implementation during Sprint 1.
+ *
+ * @todo    Implement radar_fault_detect, lidar_fault_detect,
+ *          kalman_fusion, perception_step.
+ */
+
+#include "aeb_perception.h"
+#include "aeb_config.h"
+
+/* ========================================================================= */
+/*  Stub implementations                                                     */
+/* ========================================================================= */
+
+void perception_init(void)
+{
+    /* STUB: no internal state to initialise yet. */
+}
+
+uint8_t radar_fault_detect(float32_t d_radar, float32_t vr_radar)
+{
+    (void)d_radar;
+    (void)vr_radar;
+    /* STUB: no fault detected. */
+    return 0U;
+}
+
+uint8_t lidar_fault_detect(float32_t d_lidar)
+{
+    (void)d_lidar;
+    /* STUB: no fault detected. */
+    return 0U;
+}
+
+void kalman_fusion(float32_t d_radar, float32_t vr_radar,
+                   float32_t d_lidar, float32_t v_ego,
+                   uint8_t radar_valid, uint8_t lidar_valid,
+                   perception_output_t *output)
+{
+    (void)d_radar;
+    (void)vr_radar;
+    (void)d_lidar;
+    (void)radar_valid;
+    (void)lidar_valid;
+
+    /* STUB: pass-through with safe defaults. */
+    output->distance   = 300.0f;
+    output->v_ego      = v_ego;
+    output->v_rel      = 0.0f;
+    output->confidence = 1.0f;
+    output->fault_flag = 0U;
+}
+
+void perception_step(float32_t d_radar, float32_t vr_radar,
+                     float32_t d_lidar, float32_t v_ego,
+                     perception_output_t *output)
+{
+    /* STUB: delegate to kalman_fusion with all sensors valid. */
+    kalman_fusion(d_radar, vr_radar, d_lidar, v_ego, 1U, 1U, output);
+}


### PR DESCRIPTION
# Summary
- Add shared interface contract headers (`aeb_types.h`, `aeb_config.h`) defining all structs, enumerations, and calibration parameters.
- Add module API headers for all five tasks (A through E) with Doxygen-documented function signatures and requirement traceability.
- Add stub implementations for all modules returning safe default values (no braking, no alert, no fault).
- Add `main.c` entry point calling all module init functions.
- Add `CMakeLists.txt` with dual build support (Zephyr target and native GCC for PC testing).
- Add `prj.conf` with Zephyr kernel, CAN, GPIO, and timer configuration.
- Add `.gitignore` and `README.md` with project documentation.

# Related Issue
Closes #

# Change Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] test
- [ ] ci
- [x] refactor/chore

# AEB Areas Affected
- [x] Perception
- [x] Decision Logic
- [x] Driver Alerts
- [x] Braking Control
- [x] State Machine
- [x] CAN Interface
- [x] UDS Diagnostics
- [x] Integration
- [x] Documentation only

# Requirements Impacted

## Functional Requirements
- FR-COD-001 (structural correspondence between model and C functions)
- FR-COD-003 (bidirectional traceability between requirements and code)

## Non-Functional Requirements
- NFR-COD-005 (exclusive use of fixed-width types)
- NFR-POR-001 (platform-independent C, compiles with GCC)
- NFR-POR-002 (calibration parameters separated in aeb_config.h)
- NFR-POR-003 (modular architecture with well-defined interfaces)

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [ ] Tests
- [ ] CI workflow
- [x] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [ ] Automated tests pass
- [ ] CI passes
- [ ] Traceability updated
- [x] Safety-relevant impact assessed
- [x] Documentation updated

## Evidence

Build validation with strict MISRA-aligned compiler flags:

```bash
gcc -Wall -Wextra -Wpedantic -Werror -Wshadow -Wconversion -Wdouble-promotion -std=c11 \
  -I include \
  src/perception/aeb_perception.c \
  src/decision/aeb_ttc.c \
  src/decision/aeb_fsm.c \
  src/execution/aeb_pid.c \
  src/execution/aeb_alert.c \
  src/communication/aeb_can.c \
  src/communication/aeb_uds.c \
  src/main.c \
  -o build/aeb_main
```

Result: **zero errors, zero warnings**. Binary executes successfully (exit code 0).

No CCRs / CCRm / CCRb impact — this is the project skeleton with stub implementations only. All stubs return safe defaults (no braking action).

# Reviewer Notes
- Verify that struct definitions in `aeb_types.h` match the Simulink model signal names.
- Verify that calibration values in `aeb_config.h` match SRS v2.0 Tables 10, 14, and AEB_Tasks Section 3.2.
- All `.c` files are stubs marked with `@todo` — full implementations will be delivered in Sprint 1 feature branches.

# Risks / Open Points
- `CMakeLists.txt` and `prj.conf` are untested against Zephyr SDK (no Zephyr toolchain available in current environment). Target board overlay in `boards/` is still empty.
- Unit test directory `tests/` is empty — test files will be added per module during Sprint 1.
- Task ownership follows AEB_Tasks v1.0 assignments. Any reassignment should be reflected in file headers.
