### PR TITLE
feat: CAN bus communication module (FR-CAN-001..004)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ SRC_ALL = src/communication/aeb_can.c \
 # Smoke test (baseline — always present)
 SRC_SMOKE = src/communication/aeb_can.c stubs/can_hal.c tests/test_smoke.c
 
+# CAN module tests (Task D)
+SRC_CAN_TEST = src/communication/aeb_can.c stubs/can_hal.c tests/test_can.c
+
 # Real module sources for MISRA check (add files here as stubs are replaced)
-SRC_MISRA =
+SRC_MISRA = src/communication/aeb_can.c
 
 .PHONY: build test misra clean
 
@@ -32,10 +35,14 @@ build:
 	$(CC) $(CFLAGS) -c $(SRC_ALL)
 	@echo "=== Build OK: zero warnings ==="
 
-test: test_smoke
+test: test_smoke test_can
 	./test_smoke
+	./test_can
 
 test_smoke: $(SRC_SMOKE)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_can: $(SRC_CAN_TEST)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 misra:
@@ -47,3 +54,5 @@ endif
 
 clean:
 	rm -f test_smoke test_can *.o
+
+.PHONY: test_can

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -5,7 +5,7 @@
  * Implements FR-CAN-001..004 from the AEB SRS v2.0.
  * Designed for Zephyr RTOS CAN driver; MISRA C:2012 compliant.
  *
- * @author  Renato Fagundes (Task D)
+ * @author  Renato Fagundes
  * @date    2026-04-07
  */
 

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -2,7 +2,7 @@
  * @file  aeb_config.h
  * @brief Calibration parameters for the AEB system (NFR-POR-002).
  *
- * Only the CAN-relevant subset is included here for Task D compilation.
+ * CAN-relevant subset of calibration parameters.
  * Full file maintained by Task E (Rian).
  */
 

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -43,7 +43,7 @@ typedef struct
     float32_t state_timer;    /**< s                       */
 } fsm_output_t;
 
-/** @brief PID brake output (Task C -> Task D TX). */
+/** @brief PID brake output (PID brake -> CAN TX). */
 typedef struct
 {
     float32_t brake_pct;      /**< [0, 100] %              */
@@ -58,7 +58,7 @@ typedef struct
     uint8_t   buzzer_cmd;     /**< 0..4 (beep pattern)     */
 } alert_output_t;
 
-/** @brief Driver inputs (Task D RX -> Tasks B, C). */
+/** @brief Driver inputs (CAN RX -> Decision, Execution). */
 typedef struct
 {
     uint8_t   brake_pedal;    /**< boolean                 */

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -1,89 +1,460 @@
 /**
  * @file  aeb_can.c
- * @brief CAN Bus Communication — STUB (Task D placeholder).
+ * @brief CAN Bus Communication module — implementation.
  *
- * This file will be replaced by Renato's implementation.
- * Provides empty function bodies so the project compiles and CI passes.
+ * Covers FR-CAN-001..004 from SRS v2.0.
+ * All signal layouts match aeb_system.dbc.
+ * MISRA C:2012 compliant: no malloc, no recursion, fixed-width types,
+ * all variables initialised, single return per function (preferred),
+ * bounded loops, default in every switch.
+ *
+ * @author  Renato Fagundes
+ * @date    2026-04-07
  */
 
 #include "aeb_can.h"
-#include "can_hal.h"
+#include "can_hal.h"   /* Zephyr CAN HAL stub / real driver */
 #include <string.h>
 
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PRIVATE HELPERS — Signal pack / unpack  (FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Pack an unsigned raw value into a little-endian CAN payload.
+ */
 void can_pack_signal(uint8_t *data,
                      uint8_t  start_bit,
                      uint8_t  length,
                      uint32_t raw_value)
 {
-    (void)data;
-    (void)start_bit;
-    (void)length;
-    (void)raw_value;
+    uint8_t bit_idx = 0U;
+
+    for (bit_idx = 0U; bit_idx < length; bit_idx++)
+    {
+        uint8_t  abs_bit  = start_bit + bit_idx;
+        uint8_t  byte_pos = abs_bit / 8U;
+        uint8_t  bit_pos  = abs_bit % 8U;
+        uint8_t  bit_val  = (uint8_t)((raw_value >> bit_idx) & 1U);
+
+        /* Clear then set the target bit */
+        data[byte_pos] = (uint8_t)(data[byte_pos] & (uint8_t)(~(1U << bit_pos)));
+        data[byte_pos] = (uint8_t)(data[byte_pos] | (uint8_t)(bit_val << bit_pos));
+    }
 }
 
+/**
+ * @brief Unpack an unsigned raw value from a little-endian CAN payload.
+ */
 uint32_t can_unpack_signal(const uint8_t *data,
                            uint8_t        start_bit,
                            uint8_t        length)
 {
-    (void)data;
-    (void)start_bit;
-    (void)length;
-    return 0U;
+    uint32_t result  = 0U;
+    uint8_t  bit_idx = 0U;
+
+    for (bit_idx = 0U; bit_idx < length; bit_idx++)
+    {
+        uint8_t  abs_bit  = start_bit + bit_idx;
+        uint8_t  byte_pos = abs_bit / 8U;
+        uint8_t  bit_pos  = abs_bit % 8U;
+        uint8_t  bit_val  = (uint8_t)((data[byte_pos] >> bit_pos) & 1U);
+
+        result |= ((uint32_t)bit_val << bit_idx);
+    }
+
+    return result;
 }
 
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PRIVATE — Physical-to-raw / raw-to-physical conversions
+ *
+ *  DBC formula: physical = raw * factor + offset
+ *  Encode:      raw = (physical - offset) / factor
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+static uint32_t encode_unsigned(float32_t physical,
+                                float32_t factor,
+                                float32_t offset)
+{
+    float32_t raw_f = (physical - offset) / factor;
+    uint32_t  raw   = 0U;
+
+    if (raw_f < 0.0F)
+    {
+        raw = 0U;
+    }
+    else
+    {
+        raw = (uint32_t)(raw_f + 0.5F);  /* round to nearest */
+    }
+
+    return raw;
+}
+
+static float32_t decode_unsigned(uint32_t  raw,
+                                 float32_t factor,
+                                 float32_t offset)
+{
+    return ((float32_t)raw * factor) + offset;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PRIVATE — CRC-4 computation for BrakeCmd alive monitoring
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+static uint8_t compute_crc4(const uint8_t *data, uint8_t len)
+{
+    uint8_t crc = 0x0FU;   /* Initial value, all ones for 4-bit CRC */
+    uint8_t i   = 0U;
+
+    for (i = 0U; i < len; i++)
+    {
+        uint8_t j = 0U;
+
+        crc ^= (data[i] & 0x0FU);
+        for (j = 0U; j < 4U; j++)
+        {
+            if ((crc & 0x08U) != 0U)
+            {
+                crc = (uint8_t)((crc << 1U) ^ 0x03U);  /* Poly x^4+x+1 */
+            }
+            else
+            {
+                crc = (uint8_t)(crc << 1U);
+            }
+            crc &= 0x0FU;
+        }
+
+        crc ^= ((data[i] >> 4U) & 0x0FU);
+        for (j = 0U; j < 4U; j++)
+        {
+            if ((crc & 0x08U) != 0U)
+            {
+                crc = (uint8_t)((crc << 1U) ^ 0x03U);
+            }
+            else
+            {
+                crc = (uint8_t)(crc << 1U);
+            }
+            crc &= 0x0FU;
+        }
+    }
+
+    return crc;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PUBLIC API
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Initialise CAN driver at 500 kbit/s, register RX filters.
+ * @req FR-CAN-004
+ */
 int32_t can_init(can_state_t *state)
 {
-    if (state != (void *)0)
+    int32_t result = CAN_OK;
+
+    /* Zero the entire state */
+    (void)memset(state, 0, sizeof(can_state_t));
+
+    /* Initialise CAN peripheral via HAL */
+    if (can_hal_init(CAN_BAUD_500K) != 0)
     {
-        (void)memset(state, 0, sizeof(can_state_t));
+        result = CAN_ERR_INIT;
     }
-    return CAN_OK;
+    else
+    {
+        /* Register RX filters for the three messages we receive */
+        (void)can_hal_add_rx_filter(CAN_ID_EGO_VEHICLE);
+        (void)can_hal_add_rx_filter(CAN_ID_DRIVER_INPUT);
+        (void)can_hal_add_rx_filter(CAN_ID_RADAR_TARGET);
+
+        state->initialised = 1U;
+    }
+
+    return result;
 }
 
-void can_rx_process(can_state_t *state,
-                    uint32_t id,
+/**
+ * @brief Decode a received CAN frame into the internal RX struct.
+ * @req FR-CAN-002, FR-CAN-003
+ */
+void can_rx_process(can_state_t   *state,
+                    uint32_t       id,
                     const uint8_t *data,
-                    uint8_t dlc)
+                    uint8_t        dlc)
 {
-    (void)state;
-    (void)id;
-    (void)data;
-    (void)dlc;
+    if ((state != NULL) && (data != NULL))
+    {
+    if (id == CAN_ID_EGO_VEHICLE)
+    {
+        if (dlc >= CAN_DLC_EGO_VEHICLE)
+        {
+            /* VehicleSpeed:  bits 0..15, factor 0.01, offset 0 */
+            uint32_t raw_spd = can_unpack_signal(data, 0U, 16U);
+            state->last_rx.vehicle_speed = decode_unsigned(raw_spd, 0.01F, 0.0F);
+
+            /* LongAccel:  bits 16..31, factor 0.001, offset -32
+             * DBC @1+ = unsigned raw with offset */
+            uint32_t raw_acc = can_unpack_signal(data, 16U, 16U);
+            state->last_rx.long_accel = decode_unsigned(raw_acc, 0.001F, -32.0F);
+
+            /* YawRate:  bits 32..47, factor 0.01, offset -327.68 */
+            uint32_t raw_yaw = can_unpack_signal(data, 32U, 16U);
+            state->last_rx.yaw_rate = decode_unsigned(raw_yaw, 0.01F, -327.68F);
+
+            /* SteeringAngle:  bits 48..63, factor 0.1, offset -3276.8 */
+            uint32_t raw_str = can_unpack_signal(data, 48U, 16U);
+            state->last_rx.steering_angle = decode_unsigned(raw_str, 0.1F, -3276.8F);
+        }
+    }
+    else if (id == CAN_ID_DRIVER_INPUT)
+    {
+        if (dlc >= CAN_DLC_DRIVER_INPUT)
+        {
+            /* BrakePedal:  bits 0..7, factor 1, offset 0 */
+            uint32_t raw_bp = can_unpack_signal(data, 0U, 8U);
+            state->last_rx.brake_pedal = (uint8_t)raw_bp;
+
+            /* AccelPedal:  bits 8..15, factor 1, offset 0 */
+            uint32_t raw_ap = can_unpack_signal(data, 8U, 8U);
+            state->last_rx.accel_pedal = (uint8_t)raw_ap;
+
+            /* AEB_Enable:  bit 16, 1 bit */
+            uint32_t raw_en = can_unpack_signal(data, 16U, 1U);
+            state->last_rx.aeb_enable = (uint8_t)raw_en;
+
+            /* DriverOverride:  bit 17, 1 bit */
+            uint32_t raw_ov = can_unpack_signal(data, 17U, 1U);
+            state->last_rx.driver_override = (uint8_t)raw_ov;
+        }
+    }
+    else if (id == CAN_ID_RADAR_TARGET)
+    {
+        if (dlc >= CAN_DLC_RADAR_TARGET)
+        {
+            /* TargetDistance:  bits 0..15, factor 0.01, offset 0 */
+            uint32_t raw_dist = can_unpack_signal(data, 0U, 16U);
+            state->last_rx.target_distance = decode_unsigned(raw_dist, 0.01F, 0.0F);
+
+            /* RelativeSpeed:  bits 16..31, factor 0.01, offset -327.68
+             * DBC @1+ = unsigned raw with offset */
+            uint32_t raw_vrel = can_unpack_signal(data, 16U, 16U);
+            state->last_rx.relative_speed = decode_unsigned(raw_vrel, 0.01F, -327.68F);
+
+            /* TTC:  bits 32..47, factor 0.001, offset 0 */
+            uint32_t raw_ttc = can_unpack_signal(data, 32U, 16U);
+            state->last_rx.ttc_radar = decode_unsigned(raw_ttc, 0.001F, 0.0F);
+
+            /* Confidence:  bits 48..55, factor 1, offset 0 */
+            uint32_t raw_conf = can_unpack_signal(data, 48U, 8U);
+            state->last_rx.confidence_raw = (uint8_t)raw_conf;
+
+            /* Valid frame received — reset miss counter */
+            state->rx_miss_count = 0U;
+            state->last_rx.rx_timeout_flag = 0U;
+        }
+    }
+    else
+    {
+        /* Unknown ID — ignore (MISRA: all paths handled) */
+    }
+    } /* end null guard */
 }
 
+/**
+ * @brief Check for RX timeout.  Call once per 10 ms tick.
+ * @req FR-CAN-002 (timeout: 3 × 20 ms = 60 ms)
+ */
 void can_check_timeout(can_state_t *state)
 {
-    (void)state;
+    if (state != NULL)
+    {
+    if (state->rx_miss_count < 255U)
+    {
+        state->rx_miss_count++;
+    }
+
+    /*
+     * Radar period = 20 ms, our tick = 10 ms.
+     * 3 missed frames ≈ 6 ticks of 10 ms = 60 ms.
+     * We use CAN_RX_TIMEOUT_CYCLES (3) as a count of our 20-ms-equivalent
+     * intervals, so threshold = 3 * 2 = 6 ticks.
+     */
+    if (state->rx_miss_count >= (CAN_RX_TIMEOUT_CYCLES * 2U))
+    {
+        state->last_rx.rx_timeout_flag = 1U;
+    }
+    } /* end null guard */
 }
 
-int32_t can_tx_brake_cmd(can_state_t *state,
+/**
+ * @brief Transmit AEB_BrakeCmd (0x080) with alive counter and CRC.
+ * @req FR-CAN-003
+ */
+int32_t can_tx_brake_cmd(can_state_t       *state,
                          const pid_output_t *pid_out,
                          const fsm_output_t *fsm_out)
 {
-    (void)state;
-    (void)pid_out;
-    (void)fsm_out;
-    return CAN_OK;
+    int32_t result = CAN_OK;
+
+    if ((state == NULL) || (pid_out == NULL) || (fsm_out == NULL))
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        uint8_t frame[8]   = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U};
+        uint8_t brake_mode = 0U;
+
+        /* BrakeRequest: bit 0, 1 bit */
+        uint32_t brake_req = (pid_out->brake_pct > 0.0F) ? 1U : 0U;
+        can_pack_signal(frame, 0U, 1U, brake_req);
+
+        /* BrakePressure: bits 1..15, factor 0.1, offset 0 */
+        uint32_t raw_press = encode_unsigned(pid_out->brake_bar, 0.1F, 0.0F);
+        can_pack_signal(frame, 1U, 15U, raw_press);
+
+        /* BrakeMode: bits 16..18, 3 bits — map FSM state to brake mode */
+        switch (fsm_out->fsm_state)
+        {
+            case (uint8_t)FSM_OFF:        brake_mode = 0U; break;
+            case (uint8_t)FSM_STANDBY:    brake_mode = 0U; break;
+            case (uint8_t)FSM_WARNING:    brake_mode = 1U; break;
+            case (uint8_t)FSM_BRAKE_L1:   brake_mode = 2U; break;
+            case (uint8_t)FSM_BRAKE_L2:   brake_mode = 3U; break;
+            case (uint8_t)FSM_BRAKE_L3:   brake_mode = 4U; break;
+            case (uint8_t)FSM_POST_BRAKE: brake_mode = 5U; break;
+            default:                      brake_mode = 0U; break;
+        }
+        can_pack_signal(frame, 16U, 3U, (uint32_t)brake_mode);
+
+        /* AliveCounter: bits 24..27, 4 bits */
+        can_pack_signal(frame, 24U, 4U, (uint32_t)state->alive_counter);
+
+        /* CRC: bits 28..31, 4 bits — computed over bytes 0..2 */
+        uint8_t crc = compute_crc4(frame, 3U);
+        can_pack_signal(frame, 28U, 4U, (uint32_t)crc);
+
+        /* Increment alive counter (wraps at 15) */
+        state->alive_counter++;
+        if (state->alive_counter > ALIVE_COUNTER_MAX)
+        {
+            state->alive_counter = 0U;
+        }
+
+        /* Send via HAL */
+        if (can_hal_send(CAN_ID_BRAKE_CMD, frame, CAN_DLC_BRAKE_CMD) != 0)
+        {
+            result = CAN_ERR_TX;
+        }
+    }
+
+    return result;
 }
 
-int32_t can_tx_fsm_state(can_state_t *state,
+/**
+ * @brief Transmit AEB_FSMState (0x200) every 50 ms.
+ * @req FR-CAN-001
+ */
+int32_t can_tx_fsm_state(can_state_t       *state,
                          const fsm_output_t *fsm_out)
 {
-    (void)state;
-    (void)fsm_out;
-    return 1;
+    int32_t result = 1;   /* 1 = not yet due */
+
+    if ((state == NULL) || (fsm_out == NULL))
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        state->tx_cycle_counter++;
+
+        /* 50 ms / 10 ms = every 5 ticks */
+        if (state->tx_cycle_counter >= 5U)
+        {
+            uint8_t frame[4] = {0U, 0U, 0U, 0U};
+
+            state->tx_cycle_counter = 0U;
+
+            /* FSMState: bits 0..7 */
+            can_pack_signal(frame, 0U, 8U, (uint32_t)fsm_out->fsm_state);
+
+            /* AlertLevel: bits 8..15 */
+            can_pack_signal(frame, 8U, 8U, (uint32_t)fsm_out->alert_level);
+
+            /* BrakeActive: bits 16..23 */
+            can_pack_signal(frame, 16U, 8U, (uint32_t)fsm_out->brake_active);
+
+            /* TTCThreshold: bits 24..31, factor 0.1, offset 0 */
+            float32_t ttc_thresh = 0.0F;
+            switch (fsm_out->fsm_state)
+            {
+                case (uint8_t)FSM_WARNING:    ttc_thresh = TTC_WARNING;  break;
+                case (uint8_t)FSM_BRAKE_L1:   ttc_thresh = TTC_BRAKE_L1; break;
+                case (uint8_t)FSM_BRAKE_L2:   ttc_thresh = TTC_BRAKE_L2; break;
+                case (uint8_t)FSM_BRAKE_L3:   ttc_thresh = TTC_BRAKE_L3; break;
+                default:                      ttc_thresh = 0.0F;         break;
+            }
+            uint32_t raw_ttc = encode_unsigned(ttc_thresh, 0.1F, 0.0F);
+            can_pack_signal(frame, 24U, 8U, raw_ttc);
+
+            if (can_hal_send(CAN_ID_FSM_STATE, frame, CAN_DLC_FSM_STATE) != 0)
+            {
+                result = CAN_ERR_TX;
+            }
+            else
+            {
+                result = CAN_OK;
+            }
+        }
+    }
+
+    return result;
 }
 
+/**
+ * @brief Transmit AEB_Alert (0x300).
+ * @req FR-CAN-003
+ */
 int32_t can_tx_alert(const alert_output_t *alert_out)
 {
-    (void)alert_out;
-    return CAN_OK;
+    int32_t result = CAN_OK;
+
+    if (alert_out == NULL)
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        uint8_t frame[2] = {0U, 0U};
+        /* AlertType: bits 0..7, 8 bits, factor 1, offset 0 */
+        can_pack_signal(frame, 0U, 8U, (uint32_t)alert_out->alert_type);
+
+        /* AlertActive: bit 8, 1 bit */
+        can_pack_signal(frame, 8U, 1U, (uint32_t)alert_out->alert_active);
+
+        /* BuzzerCmd: bits 9..11, 3 bits */
+        can_pack_signal(frame, 9U, 3U, (uint32_t)alert_out->buzzer_cmd);
+
+        if (can_hal_send(CAN_ID_ALERT, frame, CAN_DLC_ALERT) != 0)
+        {
+            result = CAN_ERR_TX;
+        }
+    }
+
+    return result;
 }
 
+/**
+ * @brief Copy latest RX data to caller's struct.
+ */
 void can_get_rx_data(const can_state_t *state,
-                     can_rx_data_t *out)
+                     can_rx_data_t     *out)
 {
-    if ((state != (void *)0) && (out != (void *)0))
+    if ((state != NULL) && (out != NULL))
     {
         (void)memcpy(out, &state->last_rx, sizeof(can_rx_data_t));
     }

--- a/tests/test_can.c
+++ b/tests/test_can.c
@@ -1,0 +1,363 @@
+/**
+ * @file  test_can.c
+ * @brief Unit tests for aeb_can module.
+ *
+ * Uses a minimal assert framework for host compilation.
+ * Can be adapted to Zephyr ztest by replacing ASSERT macros.
+ */
+
+#include "aeb_can.h"
+#include "can_hal.h"
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+/* ── Minimal test framework ─────────────────────────────────────────── */
+static int32_t tests_run    = 0;
+static int32_t tests_passed = 0;
+static int32_t tests_failed = 0;
+
+#define ASSERT_EQ(a, b) do { \
+    if ((a) == (b)) { tests_passed++; } \
+    else { printf("  FAIL: %s:%d  %s != %s\n", __FILE__, __LINE__, #a, #b); tests_failed++; } \
+    tests_run++; \
+} while (0)
+
+#define ASSERT_FLOAT_NEAR(a, b, tol) do { \
+    if (fabsf((float)(a) - (float)(b)) <= (float)(tol)) { tests_passed++; } \
+    else { printf("  FAIL: %s:%d  %s=%.4f != %s=%.4f (tol=%.4f)\n", \
+           __FILE__, __LINE__, #a, (double)(a), #b, (double)(b), (double)(tol)); tests_failed++; } \
+    tests_run++; \
+} while (0)
+
+#define TEST(name) static void name(void)
+#define RUN(name) do { printf("  [TEST] %s\n", #name); name(); } while (0)
+
+/* ── Extern test helpers from can_hal.c stub ────────────────────────── */
+extern uint32_t       can_hal_test_get_tx_count(void);
+extern void           can_hal_test_reset(void);
+extern void           can_hal_test_force_init_fail(int32_t fail);
+extern void           can_hal_test_force_send_fail(int32_t fail);
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: Signal pack/unpack round-trip  (FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_signal_roundtrip)
+{
+    uint8_t buf[8] = {0};
+
+    /* Pack 0xABCD into bits 4..19 (16 bits) */
+    can_pack_signal(buf, 4U, 16U, 0xABCDU);
+    uint32_t val = can_unpack_signal(buf, 4U, 16U);
+    ASSERT_EQ(val, 0xABCDU);
+
+    /* Pack single bit */
+    (void)memset(buf, 0, sizeof(buf));
+    can_pack_signal(buf, 0U, 1U, 1U);
+    ASSERT_EQ(can_unpack_signal(buf, 0U, 1U), 1U);
+    ASSERT_EQ(buf[0] & 0x01U, 0x01U);
+
+    /* Pack 4-bit value at bit 24 */
+    (void)memset(buf, 0, sizeof(buf));
+    can_pack_signal(buf, 24U, 4U, 0x0FU);
+    ASSERT_EQ(can_unpack_signal(buf, 24U, 4U), 0x0FU);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: can_init success and failure  (FR-CAN-004)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_init_success)
+{
+    can_state_t state;
+    can_hal_test_reset();
+
+    int32_t rc = can_init(&state);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(state.initialised, 1U);
+    ASSERT_EQ(state.alive_counter, 0U);
+}
+
+TEST(test_init_failure)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    can_hal_test_force_init_fail(1);
+
+    int32_t rc = can_init(&state);
+    ASSERT_EQ(rc, CAN_ERR_INIT);
+    ASSERT_EQ(state.initialised, 0U);
+
+    can_hal_test_force_init_fail(0);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — EgoVehicle (0x100)  (FR-CAN-002, FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_ego_vehicle)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* Construct a frame: VehicleSpeed=13.89 m/s (50 km/h)
+     * raw = 13.89 / 0.01 = 1389 = 0x056D */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 0U, 16U, 1389U);   /* VehicleSpeed */
+
+    /* LongAccel = -2.0 m/s^2 → raw = (-2.0 - (-32)) / 0.001 = 30000 */
+    can_pack_signal(frame, 16U, 16U, 30000U);
+
+    /* SteeringAngle = 10.0 deg → raw = (10.0 - (-3276.8)) / 0.1 = 32868 */
+    can_pack_signal(frame, 48U, 16U, 32868U);
+
+    can_rx_process(&state, CAN_ID_EGO_VEHICLE, frame, 8U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_FLOAT_NEAR(rx.vehicle_speed, 13.89F, 0.02F);
+    ASSERT_FLOAT_NEAR(rx.long_accel, -2.0F, 0.01F);
+    ASSERT_FLOAT_NEAR(rx.steering_angle, 10.0F, 0.2F);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — RadarTarget (0x120)  (FR-CAN-002, FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_radar_target)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* TargetDistance = 50.0 m → raw = 50.0 / 0.01 = 5000 */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 0U, 16U, 5000U);
+
+    /* RelativeSpeed = -5.0 m/s → raw = (-5.0 - (-327.68)) / 0.01 = 32268 */
+    can_pack_signal(frame, 16U, 16U, 32268U);
+
+    /* TTC = 3.5 s → raw = 3.5 / 0.001 = 3500 */
+    can_pack_signal(frame, 32U, 16U, 3500U);
+
+    /* Confidence = 12 */
+    can_pack_signal(frame, 48U, 8U, 12U);
+
+    can_rx_process(&state, CAN_ID_RADAR_TARGET, frame, 8U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_FLOAT_NEAR(rx.target_distance, 50.0F, 0.02F);
+    ASSERT_FLOAT_NEAR(rx.relative_speed, -5.0F, 0.02F);
+    ASSERT_FLOAT_NEAR(rx.ttc_radar, 3.5F, 0.002F);
+    ASSERT_EQ(rx.confidence_raw, 12U);
+    ASSERT_EQ(rx.rx_timeout_flag, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — DriverInput (0x101)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_driver_input)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* BrakePedal=80%, AccelPedal=0%, AEB_Enable=1, DriverOverride=0 */
+    uint8_t frame[4] = {0};
+    can_pack_signal(frame, 0U, 8U, 80U);   /* BrakePedal */
+    can_pack_signal(frame, 8U, 8U, 0U);    /* AccelPedal */
+    can_pack_signal(frame, 16U, 1U, 1U);   /* AEB_Enable */
+    can_pack_signal(frame, 17U, 1U, 0U);   /* DriverOverride */
+
+    can_rx_process(&state, CAN_ID_DRIVER_INPUT, frame, 4U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_EQ(rx.brake_pedal, 80U);
+    ASSERT_EQ(rx.accel_pedal, 0U);
+    ASSERT_EQ(rx.aeb_enable, 1U);
+    ASSERT_EQ(rx.driver_override, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — YawRate from EgoVehicle
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_yaw_rate)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* YawRate = 5.0 deg/s -> raw = (5.0 - (-327.68)) / 0.01 = 33268 */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 32U, 16U, 33268U);
+
+    can_rx_process(&state, CAN_ID_EGO_VEHICLE, frame, 8U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_FLOAT_NEAR(rx.yaw_rate, 5.0F, 0.02F);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX Alert (0x300)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_alert)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    alert_output_t alert = { .alert_type = 3U, .alert_active = 1U, .buzzer_cmd = 4U };
+
+    int32_t rc = can_tx_alert(&alert);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX timeout detection  (FR-CAN-002 acceptance: 60 ms)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_timeout)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* Simulate 6 ticks (60 ms) with no RX */
+    uint8_t i = 0U;
+    for (i = 0U; i < 6U; i++)
+    {
+        can_check_timeout(&state);
+    }
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+    ASSERT_EQ(rx.rx_timeout_flag, 1U);
+}
+
+TEST(test_rx_timeout_reset_on_valid_frame)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* 5 ticks without data */
+    uint8_t i = 0U;
+    for (i = 0U; i < 5U; i++)
+    {
+        can_check_timeout(&state);
+    }
+
+    /* Valid radar frame arrives — should reset counter */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 0U, 16U, 1000U); /* 10m */
+    can_rx_process(&state, CAN_ID_RADAR_TARGET, frame, 8U);
+
+    /* 1 more tick — should NOT be timed out */
+    can_check_timeout(&state);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+    ASSERT_EQ(rx.rx_timeout_flag, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX BrakeCmd encoding  (FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_brake_cmd)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    pid_output_t pid = { .brake_pct = 75.0F, .brake_bar = 7.5F };
+    fsm_output_t fsm = {0};
+    fsm.fsm_state   = (uint8_t)FSM_BRAKE_L3;
+    fsm.brake_active = 1U;
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+
+    /* Alive counter should have incremented */
+    ASSERT_EQ(state.alive_counter, 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX FSM State at 50 ms period  (FR-CAN-001)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_fsm_period)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    fsm_output_t fsm = {0};
+    fsm.fsm_state = (uint8_t)FSM_WARNING;
+    fsm.alert_level = 1U;
+
+    /* First 4 ticks: should NOT transmit (return 1 = not due) */
+    int32_t rc = 0;
+    uint8_t i = 0U;
+    for (i = 0U; i < 4U; i++)
+    {
+        rc = can_tx_fsm_state(&state, &fsm);
+        ASSERT_EQ(rc, 1);
+    }
+
+    /* 5th tick: SHOULD transmit */
+    rc = can_tx_fsm_state(&state, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX failure handling
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_send_failure)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+    can_hal_test_force_send_fail(1);
+
+    pid_output_t pid = { .brake_pct = 50.0F, .brake_bar = 5.0F };
+    fsm_output_t fsm = {0};
+    fsm.fsm_state = (uint8_t)FSM_BRAKE_L1;
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_ERR_TX);
+
+    can_hal_test_force_send_fail(0);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  MAIN
+ * ═══════════════════════════════════════════════════════════════════════ */
+int main(void)
+{
+    printf("=== AEB CAN Module — Unit Tests ===\n\n");
+
+    RUN(test_signal_roundtrip);
+    RUN(test_init_success);
+    RUN(test_init_failure);
+    RUN(test_rx_ego_vehicle);
+    RUN(test_rx_yaw_rate);
+    RUN(test_rx_radar_target);
+    RUN(test_rx_driver_input);
+    RUN(test_tx_alert);
+    RUN(test_rx_timeout);
+    RUN(test_rx_timeout_reset_on_valid_frame);
+    RUN(test_tx_brake_cmd);
+    RUN(test_tx_fsm_period);
+    RUN(test_tx_send_failure);
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n",
+           tests_run, tests_passed, tests_failed);
+
+    return (tests_failed > 0) ? 1 : 0;
+}


### PR DESCRIPTION
# Summary
- Replace CAN stub with full DBC-compliant implementation
- Encode/decode all 6 CAN messages (BrakeCmd, EgoVehicle, DriverInput, RadarTarget, FSMState, Alert)
- RX timeout detection (60 ms), alive counter with CRC-4
- 50 ms FSM state TX, event-driven alert TX
- Add 13 unit tests (36 assertions, all passing)
- Enable MISRA C:2012 check on real CAN module in CI

# Related Issue
Closes #37
Ref #39

# Change Type
- [x] feat
- [x] test

# AEB Areas Affected
- [x] CAN Interface

# Requirements Impacted
## Functional Requirements
- FR-CAN-001: TX ego dynamics at fixed cycle (50 ms)
- FR-CAN-002: RX radar target data with timeout detection (60 ms)
- FR-CAN-003: Structured signal encoding per DBC (all 6 messages, 22 signals)
- FR-CAN-004: CAN at 500 kbit/s

## Non-Functional Requirements
- NFR-COD-001: MISRA C:2012 compliance (zero violations)
- NFR-COD-002: Fixed-width types throughout
- NFR-POR-002: Calibration parameters separated in aeb_config.h

# Artifacts Updated
- [x] C source code
- [x] Tests
- [x] CI workflow

# Validation Evidence
- [x] Local build passes (`make build` — zero warnings)
- [x] Automated tests pass (`make test` — 50/50: 14 smoke + 36 CAN)
- [x] CI passes
- [x] MISRA check passes (`make misra`)

## Evidence
```
$ make build
=== Build OK: zero warnings ===

$ make test
=== Results: 14 run, 14 passed, 0 failed ===  (smoke)
=== Results: 36 run, 36 passed, 0 failed ===  (CAN)

$ make misra
Checking src/communication/aeb_can.c ...
(only shared-header advisories — zero violations in aeb_can.c)
```

# Reviewer Notes
- Signal layouts verified against `aeb_system.dbc` and Simulink `CAN_Bus.slx`
- `stubs/can_hal.*` abstracts the Zephyr CAN driver for host testing
- The `SRC_MISRA` variable in Makefile now includes `aeb_can.c`; other modules should be added as their stubs are replaced

# Risks / Open Points
- None for this module