### PR TITLE
feat: Implement UDS diagnostic services (FR-UDS-001..005)

### DIFF
--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -2,7 +2,6 @@
  * @file  aeb_config.h
  * @brief Calibration parameters for the AEB system (NFR-POR-002).
  *
-<<<<<<< HEAD
  * All tuneable parameters centralised here, enabling independent
  * calibration without modifying source code.
  *

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -2,8 +2,17 @@
  * @file  aeb_config.h
  * @brief Calibration parameters for the AEB system (NFR-POR-002).
  *
- * Only the CAN-relevant subset is included here for Task D compilation.
- * Full file maintained by Task E (Rian).
+<<<<<<< HEAD
+ * All tuneable parameters centralised here, enabling independent
+ * calibration without modifying source code.
+ *
+ * Based on AEB_Tasks v1.0 Section 3.2.
+ *
+ * @req NFR-POR-002 Calibration separated from code.
+ * @req FR-COD-001 Structural correspondence with Simulink model.
+ *
+ * @version 2.0 — Integration
+ * @date 2026-04
  */
 
 #ifndef AEB_CONFIG_H

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -2,18 +2,26 @@
  * @file  aeb_config.h
  * @brief Calibration parameters for the AEB system (NFR-POR-002).
  *
- * Only the CAN-relevant subset is included here for Task D compilation.
- * Full file maintained by Task E (Rian).
+ * All tuneable parameters centralised here, enabling independent
+ * calibration without modifying source code.
+ *
+ * Based on AEB_Tasks v1.0 Section 3.2.
+ *
+ * @req NFR-POR-002 Calibration separated from code.
+ * @req FR-COD-001 Structural correspondence with Simulink model.
+ *
+ * @version 2.0 — Integration
+ * @date 2026-04
  */
 
 #ifndef AEB_CONFIG_H
 #define AEB_CONFIG_H
 
-/* Timing */
+/* ===== Timing (NFR-PERF-001) ===== */
 #define AEB_CYCLE_TIME_MS     10U        /**< 100 Hz                  */
 #define AEB_DT                0.01F      /**< 10 ms in seconds        */
 
-/* TTC thresholds (FR-DEC-004) */
+/* ===== TTC thresholds (FR-DEC-004) ===== */
 #define TTC_WARNING           4.0F       /**< s                       */
 #define TTC_BRAKE_L1          3.0F       /**< s                       */
 #define TTC_BRAKE_L2          2.2F       /**< s                       */
@@ -21,24 +29,49 @@
 #define TTC_MAX               10.0F      /**< s — saturation          */
 #define V_REL_MIN             0.5F       /**< m/s                     */
 
-/* Speed range (FR-DEC-008) */
+/* ===== Distance floors (Table 10) ===== */
+#define D_FLOOR_L1            20.0F      /**< m                       */
+#define D_FLOOR_L2            10.0F      /**< m                       */
+#define D_FLOOR_L3            5.0F       /**< m                       */
+
+/* ===== Speed range (FR-DEC-008) ===== */
 #define V_EGO_MIN             2.78F      /**< m/s = 10 km/h           */
 #define V_EGO_MAX             16.67F     /**< m/s = 60 km/h           */
 
-/* Deceleration levels */
+/* ===== Deceleration levels ===== */
 #define DECEL_L1              2.0F       /**< m/s^2                   */
 #define DECEL_L2              4.0F       /**< m/s^2                   */
 #define DECEL_L3              6.0F       /**< m/s^2 (= amax)          */
 
-/* CAN (FR-CAN) */
+/* ===== Hysteresis & timing ===== */
+#define HYSTERESIS_TIME       0.2F       /**< s — de-escalation       */
+#define WARNING_MIN_TIME      0.8F       /**< s — FR-ALR-003          */
+#define POST_BRAKE_HOLD       2.0F       /**< s — FR-BRK-005          */
+#define V_STOP_THRESHOLD      0.01F      /**< m/s                     */
+
+/* ===== PI controller (FR-BRK-002) ===== */
+#define PID_KP                10.0F
+#define PID_KI                0.05F
+#define PID_INTEG_MAX         50.0F      /**< % — anti-windup         */
+#define BRAKE_OUT_MAX         100.0F     /**< %                       */
+#define BRAKE_OUT_MIN         0.0F       /**< %                       */
+#define MAX_JERK              10.0F      /**< m/s^3                   */
+
+/* ===== Sensor fault (FR-PER-007) ===== */
+#define SENSOR_FAULT_CYCLES   3U         /**< consecutive bad cycles  */
+#define DIST_ROC_LIMIT        10.0F      /**< m/cycle                 */
+#define VEL_ROC_LIMIT         2.0F       /**< m/s per cycle           */
+#define STEERING_OVERRIDE_DEG 5.0F       /**< degrees                 */
+
+/* ===== CAN (FR-CAN-001..004) ===== */
 #define CAN_BAUD_RATE         500000U    /**< 500 kbit/s              */
 #define CAN_TX_PERIOD_MS      50U        /**< ego dynamics TX period  */
-#define CAN_RX_TIMEOUT_MS     60U        /**< 3 × 20 ms              */
+#define CAN_RX_TIMEOUT_MS     60U        /**< 3 x 20 ms              */
 
-/* UDS DIDs */
-#define UDS_DID_TTC           0xF100U
-#define UDS_DID_FSM_STATE     0xF101U
-#define UDS_DID_BRAKE_PRESS   0xF102U
-#define UDS_ROUTINE_AEB       0x0301U
+/* ===== UDS diagnostics (FR-UDS-001..005) ===== */
+#define UDS_DID_TTC           0xF100U    /**< DID — TTC value         */
+#define UDS_DID_FSM_STATE     0xF101U    /**< DID — FSM state         */
+#define UDS_DID_BRAKE_PRESS   0xF102U    /**< DID — Brake pressure    */
+#define UDS_ROUTINE_AEB       0x0301U    /**< RID — AEB enable/disable*/
 
 #endif /* AEB_CONFIG_H */

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -6,11 +6,12 @@
  * All modules communicate through typed structs passed by pointer.
  * No global mutable state except where Zephyr kernel objects require it.
  *
+ * Based on AEB_Tasks v1.0 Section 3.1.
  *
  * @req FR-COD-001 Structural correspondence with Simulink model.
  * @req NFR-COD-005 Exclusive use of fixed-width types.
  *
- * @version 2.0 — Integration
+ * @version 2.1 — Review fixes
  * @date 2026-04
  */
 
@@ -23,7 +24,7 @@
 typedef float float32_t;
 
 /**
- * @brief Perception output (Task A -> Task B).
+ * @brief Perception output (Perception -> Decision).
  * @req FR-PER-001..008
  */
 typedef struct
@@ -36,7 +37,7 @@ typedef struct
 } perception_output_t;
 
 /**
- * @brief TTC calculation output (Task B internal).
+ * @brief TTC calculation output (Decision internal).
  * @req FR-DEC-001, FR-DEC-002
  */
 typedef struct
@@ -47,7 +48,7 @@ typedef struct
 } ttc_output_t;
 
 /**
- * @brief FSM output (Task B -> Tasks C, D, E).
+ * @brief FSM output (Decision -> Execution, CAN, UDS).
  * @req FR-FSM-001
  */
 typedef struct
@@ -60,7 +61,10 @@ typedef struct
     float32_t state_timer;    /**< s                       */
 } fsm_output_t;
 
-/** @brief PID brake output (Task C -> Task D TX). */
+/**
+ * @brief PID brake output (PID brake -> CAN TX).
+ * @req FR-BRK-007
+ */
 typedef struct
 {
     float32_t brake_pct;      /**< [0, 100] %              */
@@ -68,7 +72,7 @@ typedef struct
 } pid_output_t;
 
 /**
- * @brief Alert output (Task C -> GPIO).
+ * @brief Alert output (Alert logic -> GPIO).
  * @req FR-ALR-001, FR-ALR-002
  */
 typedef struct
@@ -78,7 +82,10 @@ typedef struct
     uint8_t   buzzer_cmd;     /**< 0..4 (beep pattern)     */
 } alert_output_t;
 
-/** @brief Driver inputs (Task D RX -> Tasks B, C). */
+/**
+ * @brief Driver inputs (CAN RX -> Decision, Execution).
+ * @req FR-PER-004, FR-PER-005, FR-PER-008
+ */
 typedef struct
 {
     uint8_t   brake_pedal;    /**< boolean                 */

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -6,7 +6,6 @@
  * All modules communicate through typed structs passed by pointer.
  * No global mutable state except where Zephyr kernel objects require it.
  *
- * Based on AEB_Tasks v1.0 Section 3.1.
  *
  * @req FR-COD-001 Structural correspondence with Simulink model.
  * @req NFR-COD-005 Exclusive use of fixed-width types.

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -3,7 +3,16 @@
  * @brief Shared interface structs for the AEB system.
  *
  * This file is the integration contract between all modules.
+ * All modules communicate through typed structs passed by pointer.
+ * No global mutable state except where Zephyr kernel objects require it.
+ *
  * Based on AEB_Tasks v1.0 Section 3.1.
+ *
+ * @req FR-COD-001 Structural correspondence with Simulink model.
+ * @req NFR-COD-005 Exclusive use of fixed-width types.
+ *
+ * @version 2.0 — Integration
+ * @date 2026-04
  */
 
 #ifndef AEB_TYPES_H
@@ -14,7 +23,10 @@
 /** @brief 32-bit IEEE-754 floating-point type (MISRA fixed-width). */
 typedef float float32_t;
 
-/** @brief Perception output (Task A -> Task B). */
+/**
+ * @brief Perception output (Task A -> Task B).
+ * @req FR-PER-001..008
+ */
 typedef struct
 {
     float32_t distance;       /**< [0, 300] m              */
@@ -24,7 +36,10 @@ typedef struct
     uint8_t   fault_flag;     /**< 0=OK, 1=fault           */
 } perception_output_t;
 
-/** @brief TTC calculation output (Task B internal). */
+/**
+ * @brief TTC calculation output (Task B internal).
+ * @req FR-DEC-001, FR-DEC-002
+ */
 typedef struct
 {
     float32_t ttc;            /**< [0, 10] s               */
@@ -32,7 +47,10 @@ typedef struct
     uint8_t   is_closing;     /**< boolean                 */
 } ttc_output_t;
 
-/** @brief FSM output (Task B -> Tasks C, D, E). */
+/**
+ * @brief FSM output (Task B -> Tasks C, D, E).
+ * @req FR-FSM-001
+ */
 typedef struct
 {
     uint8_t   fsm_state;      /**< 0=OFF .. 6=POST_BRAKE   */
@@ -43,14 +61,20 @@ typedef struct
     float32_t state_timer;    /**< s                       */
 } fsm_output_t;
 
-/** @brief PID brake output (Task C -> Task D TX). */
+/**
+ * @brief PID brake output (Task C -> Task D TX).
+ * @req FR-BRK-007
+ */
 typedef struct
 {
     float32_t brake_pct;      /**< [0, 100] %              */
     float32_t brake_bar;      /**< [0, 10] bar             */
 } pid_output_t;
 
-/** @brief Alert output (Task C -> GPIO). */
+/**
+ * @brief Alert output (Task C -> GPIO).
+ * @req FR-ALR-001, FR-ALR-002
+ */
 typedef struct
 {
     uint8_t   alert_type;     /**< 0=NONE,1=VIS,2=AUD,3=BOTH */
@@ -58,7 +82,10 @@ typedef struct
     uint8_t   buzzer_cmd;     /**< 0..4 (beep pattern)     */
 } alert_output_t;
 
-/** @brief Driver inputs (Task D RX -> Tasks B, C). */
+/**
+ * @brief Driver inputs (Task D RX -> Tasks B, C).
+ * @req FR-PER-004, FR-PER-005, FR-PER-008
+ */
 typedef struct
 {
     uint8_t   brake_pedal;    /**< boolean                 */
@@ -67,7 +94,10 @@ typedef struct
     uint8_t   aeb_enabled;    /**< boolean                 */
 } driver_input_t;
 
-/** @brief FSM state enumeration. */
+/**
+ * @brief FSM state enumeration.
+ * @req FR-FSM-001
+ */
 typedef enum
 {
     FSM_OFF        = 0,

--- a/include/aeb_uds.h
+++ b/include/aeb_uds.h
@@ -1,0 +1,166 @@
+/**
+ * @file aeb_uds.h
+ * @brief UDS Diagnostics module API for the AEB system.
+ *
+ * Implements the UDS server: live data access (SID 0x22), DTC management
+ * (SID 0x14), fault monitoring, and AEB enable/disable (SID 0x31).
+ *
+ * Structural correspondence: Simulink chart_117 (UDS_Server).
+ *
+ * @req FR-UDS-001 ReadDataByIdentifier (SID 0x22).
+ * @req FR-UDS-002 DTC storage (C1001, C1004, C1006).
+ * @req FR-UDS-003 ClearDiagnosticInformation (SID 0x14).
+ * @req FR-UDS-004 RoutineControl (SID 0x31, routine 0x0301).
+ * @req FR-UDS-005 UDS request/response via CAN within one cycle.
+ * @req FR-COD-001 Structural correspondence with Simulink model.
+ *
+ * @version 1.0
+ * @date 2026-04
+ */
+
+#ifndef AEB_UDS_H
+#define AEB_UDS_H
+
+#include <stdint.h>
+#include "aeb_types.h"
+
+/* ===================================================================
+ * UDS Service Identifiers (ISO 14229)
+ * =================================================================== */
+
+#define UDS_SID_READ_DID            ((uint8_t)0x22U)
+#define UDS_SID_READ_DID_RESP       ((uint8_t)0x62U)
+#define UDS_SID_CLEAR_DTC           ((uint8_t)0x14U)
+#define UDS_SID_CLEAR_DTC_RESP      ((uint8_t)0x54U)
+#define UDS_SID_ROUTINE_CTRL        ((uint8_t)0x31U)
+#define UDS_SID_ROUTINE_CTRL_RESP   ((uint8_t)0x71U)
+#define UDS_SID_NEGATIVE_RESP       ((uint8_t)0x7FU)
+
+/* ===================================================================
+ * Negative Response Codes (NRC)
+ * =================================================================== */
+
+#define UDS_NRC_SERVICE_NOT_SUPP    ((uint8_t)0x11U)
+#define UDS_NRC_REQUEST_OOR         ((uint8_t)0x31U)
+
+/* ===================================================================
+ * DID Identifiers
+ * =================================================================== */
+
+#define UDS_DID_TTC_VAL             ((uint16_t)0xF100U)
+#define UDS_DID_FSM_STATE_VAL       ((uint16_t)0xF101U)
+#define UDS_DID_BRAKE_PRESS_VAL     ((uint16_t)0xF102U)
+
+/* ===================================================================
+ * Routine Identifiers
+ * =================================================================== */
+
+#define UDS_RID_AEB_CTRL            ((uint16_t)0x0301U)
+
+/* ===================================================================
+ * Data Structures
+ * =================================================================== */
+
+/**
+ * @brief UDS request — maps to UDS_Request CAN msg (ID 0x7DF / 2015).
+ */
+typedef struct
+{
+    uint8_t sid;        /**< Service Identifier                       */
+    uint8_t did_high;   /**< DID high byte                            */
+    uint8_t did_low;    /**< DID low byte                             */
+    uint8_t value;      /**< Value field (RoutineControl)             */
+} uds_request_t;
+
+/**
+ * @brief UDS response — maps to UDS_Response CAN msg (ID 0x7E8 / 2024).
+ */
+typedef struct
+{
+    uint8_t response_sid;   /**< Response SID                         */
+    uint8_t did_high_resp;  /**< DID high byte (echo or SID for NRC)  */
+    uint8_t did_low_resp;   /**< DID low byte (or NRC code)           */
+    uint8_t data1;          /**< Response data byte 1                 */
+    uint8_t data2;          /**< Response data byte 2                 */
+    uint8_t data3;          /**< Response data byte 3                 */
+    uint8_t data4;          /**< Response data byte 4                 */
+    uint8_t data5;          /**< Response data byte 5                 */
+} uds_response_t;
+
+/**
+ * @brief UDS server internal state (persistent variables).
+ *
+ * Maps to MATLAB Function persistent variables:
+ *   aeb_enabled_mem, dtc_sensor_mem, dtc_crc_mem, dtc_actuator_mem.
+ */
+typedef struct
+{
+    uint8_t aeb_enabled;    /**< AEB enable flag (persistent)          */
+    uint8_t dtc_sensor;     /**< DTC C1001: sensor fault (latched)     */
+    uint8_t dtc_crc;        /**< DTC C1004: CRC error (latched)        */
+    uint8_t dtc_actuator;   /**< DTC C1006: actuator fault (latched)   */
+} uds_state_t;
+
+/**
+ * @brief UDS server output signals.
+ */
+typedef struct
+{
+    uint8_t aeb_enabled;    /**< Current AEB enable state              */
+    uint8_t dtc_count;      /**< Number of active DTCs (0..3)          */
+    uint8_t fault_lamp;     /**< MIL lamp: 1 if dtc_count > 0         */
+} uds_output_t;
+
+/* ===================================================================
+ * Public API
+ * =================================================================== */
+
+/**
+ * @brief Initialise the UDS server state.
+ * @param[out] state  Pointer to UDS state to initialise.
+ * @req NFR-SAF-004 Power-on self-test.
+ */
+void uds_init(uds_state_t *state);
+
+/**
+ * @brief Monitor fault inputs and latch DTCs (called every 10 ms).
+ *
+ * DTCs stored immediately on first active fault (DD-UDS-01, no debounce).
+ *
+ * @param[in,out] state          UDS server state.
+ * @param[in]     sensor_fault   Sensor fault flag (0/1).
+ * @param[in]     crc_error      CRC error flag (0/1).
+ * @param[in]     actuator_fault Actuator fault flag (0/1).
+ * @req FR-UDS-002
+ */
+void uds_monitor_faults(uds_state_t *state,
+                        uint8_t sensor_fault,
+                        uint8_t crc_error,
+                        uint8_t actuator_fault);
+
+/**
+ * @brief Process a UDS request and generate the response.
+ *
+ * @param[in,out] state    UDS server state.
+ * @param[in]     request  Incoming UDS request.
+ * @param[out]    response UDS response to populate.
+ * @param[in]     fsm_out  Current FSM output (live data).
+ * @param[in]     pid_out  Current PID output (live data).
+ * @param[in]     ttc_out  Current TTC output (live data).
+ * @req FR-UDS-001, FR-UDS-003, FR-UDS-004, FR-UDS-005
+ */
+void uds_process_request(uds_state_t *state,
+                         const uds_request_t *request,
+                         uds_response_t *response,
+                         const fsm_output_t *fsm_out,
+                         const pid_output_t *pid_out,
+                         const ttc_output_t *ttc_out);
+
+/**
+ * @brief Get current UDS output signals.
+ * @param[in]  state  UDS server state.
+ * @param[out] output Output structure to populate.
+ */
+void uds_get_output(const uds_state_t *state, uds_output_t *output);
+
+#endif /* AEB_UDS_H */

--- a/include/aeb_uds.h
+++ b/include/aeb_uds.h
@@ -5,8 +5,6 @@
  * Implements the UDS server: live data access (SID 0x22), DTC management
  * (SID 0x14), fault monitoring, and AEB enable/disable (SID 0x31).
  *
- * Structural correspondence: Simulink chart_117 (UDS_Server).
- *
  * @req FR-UDS-001 ReadDataByIdentifier (SID 0x22).
  * @req FR-UDS-002 DTC storage (C1001, C1004, C1006).
  * @req FR-UDS-003 ClearDiagnosticInformation (SID 0x14).
@@ -14,6 +12,7 @@
  * @req FR-UDS-005 UDS request/response via CAN within one cycle.
  * @req FR-COD-001 Structural correspondence with Simulink model.
  *
+ * @author  Rian Linhares
  * @version 1.0
  * @date 2026-04
  */

--- a/src/communication/aeb_uds.c
+++ b/src/communication/aeb_uds.c
@@ -1,26 +1,288 @@
 /**
- * @file  aeb_uds.c
- * @brief UDS Diagnostics — STUB (Task E placeholder).
+ * @file aeb_uds.c
+ * @brief UDS Diagnostics server — C translation of Simulink UDS_Server.
  *
- * This file will be replaced by Rian's implementation.
+ * Direct translation of the MATLAB Function block (chart_117):
+ *   - Persistent variables  ->  uds_state_t struct members.
+ *   - Immediate DTC latch (DD-UDS-01).
+ *   - Scaled integer encoding for DIDs (DD-UDS-03 encoding).
+ *   - Persistent aeb_enabled across cycles (DD-UDS-02).
+ *   - Negative response 0x7F for unsupported SID/DID (DD-UDS-03).
+ *
+ * @req FR-UDS-001..005, FR-COD-001, FR-COD-003
+ *
+ * @version 1.0
+ * @date 2026-04
  */
 
-#include "aeb_types.h"
-#include <stdint.h>
+#include "aeb_uds.h"
+#include "aeb_config.h"
 
-void uds_init(void)
+/* ===================================================================
+ * Static helpers
+ * =================================================================== */
+
+/**
+ * @brief Zero-initialise a UDS response.
+ */
+static void uds_clear_response(uds_response_t *response)
 {
-    /* STUB — Task E (Rian) */
+    response->response_sid  = 0U;
+    response->did_high_resp = 0U;
+    response->did_low_resp  = 0U;
+    response->data1         = 0U;
+    response->data2         = 0U;
+    response->data3         = 0U;
+    response->data4         = 0U;
+    response->data5         = 0U;
 }
 
-void uds_process_request(const uint8_t sid,
-                         const uint8_t did_high,
-                         const uint8_t did_low,
-                         const uint8_t value)
+/**
+ * @brief Build a negative response (SID 0x7F).
+ */
+static void uds_send_negative(uds_response_t *response,
+                              uint8_t original_sid,
+                              uint8_t nrc)
 {
-    (void)sid;
-    (void)did_high;
-    (void)did_low;
-    (void)value;
-    /* STUB — Task E (Rian) */
+    response->response_sid  = UDS_SID_NEGATIVE_RESP;
+    response->did_high_resp = original_sid;
+    response->did_low_resp  = nrc;
+}
+
+/* ===================================================================
+ * SID 0x22 — ReadDataByIdentifier
+ * =================================================================== */
+
+/**
+ * @brief Handle SID 0x22.
+ *
+ * DIDs supported:
+ *   0xF100 — TTC  (scaled x100, little-endian uint16).
+ *   0xF101 — FSM state (raw uint8 in data1).
+ *   0xF102 — Brake pressure (scaled x10, little-endian uint16).
+ *
+ * @req FR-UDS-001
+ */
+static void uds_handle_read_did(const uds_request_t *request,
+                                uds_response_t *response,
+                                const fsm_output_t *fsm_out,
+                                const pid_output_t *pid_out,
+                                const ttc_output_t *ttc_out)
+{
+    uint16_t requested_id;
+    uint16_t scaled_val;
+
+    requested_id = ((uint16_t)request->did_high * 256U)
+                 + (uint16_t)request->did_low;
+
+    switch (requested_id)
+    {
+        case UDS_DID_TTC_VAL:           /* 0xF100 */
+        {
+            scaled_val = (uint16_t)(ttc_out->ttc * 100.0f);
+
+            response->response_sid  = UDS_SID_READ_DID_RESP;
+            response->did_high_resp = request->did_high;
+            response->did_low_resp  = request->did_low;
+            response->data1         = (uint8_t)(scaled_val & 0x00FFU);
+            response->data2         = (uint8_t)((scaled_val >> 8U) & 0x00FFU);
+            break;
+        }
+
+        case UDS_DID_FSM_STATE_VAL:     /* 0xF101 */
+        {
+            response->response_sid  = UDS_SID_READ_DID_RESP;
+            response->did_high_resp = request->did_high;
+            response->did_low_resp  = request->did_low;
+            response->data1         = fsm_out->fsm_state;
+            break;
+        }
+
+        case UDS_DID_BRAKE_PRESS_VAL:   /* 0xF102 */
+        {
+            scaled_val = (uint16_t)(pid_out->brake_pct * 10.0f);
+
+            response->response_sid  = UDS_SID_READ_DID_RESP;
+            response->did_high_resp = request->did_high;
+            response->did_low_resp  = request->did_low;
+            response->data1         = (uint8_t)(scaled_val & 0x00FFU);
+            response->data2         = (uint8_t)((scaled_val >> 8U) & 0x00FFU);
+            break;
+        }
+
+        default:    /* DID not supported — NRC 0x31 */
+        {
+            uds_send_negative(response,
+                              UDS_SID_READ_DID,
+                              UDS_NRC_REQUEST_OOR);
+            break;
+        }
+    }
+}
+
+/* ===================================================================
+ * SID 0x14 — ClearDiagnosticInformation
+ * =================================================================== */
+
+/**
+ * @brief Handle SID 0x14 — reset all stored DTCs.
+ * @req FR-UDS-003
+ */
+static void uds_handle_clear_dtc(uds_state_t *state,
+                                 uds_response_t *response)
+{
+    state->dtc_sensor   = 0U;
+    state->dtc_crc      = 0U;
+    state->dtc_actuator = 0U;
+
+    response->response_sid = UDS_SID_CLEAR_DTC_RESP;
+}
+
+/* ===================================================================
+ * SID 0x31 — RoutineControl
+ * =================================================================== */
+
+/**
+ * @brief Handle SID 0x31, routine 0x0301 — AEB enable/disable.
+ * @req FR-UDS-004
+ */
+static void uds_handle_routine_ctrl(uds_state_t *state,
+                                    const uds_request_t *request,
+                                    uds_response_t *response)
+{
+    uint16_t routine_id;
+
+    routine_id = ((uint16_t)request->did_high * 256U)
+               + (uint16_t)request->did_low;
+
+    if (routine_id == UDS_RID_AEB_CTRL)     /* 0x0301 */
+    {
+        if (request->value == 0U)           /* Disable */
+        {
+            state->aeb_enabled = 0U;
+
+            response->response_sid  = UDS_SID_ROUTINE_CTRL_RESP;
+            response->did_high_resp = request->did_high;
+            response->did_low_resp  = request->did_low;
+            response->data1         = 0U;
+        }
+        else if (request->value == 1U)      /* Enable */
+        {
+            state->aeb_enabled = 1U;
+
+            response->response_sid  = UDS_SID_ROUTINE_CTRL_RESP;
+            response->did_high_resp = request->did_high;
+            response->did_low_resp  = request->did_low;
+            response->data1         = 1U;
+        }
+        else                                /* Invalid value */
+        {
+            uds_send_negative(response,
+                              UDS_SID_ROUTINE_CTRL,
+                              UDS_NRC_REQUEST_OOR);
+        }
+    }
+    else                                    /* Routine not supported */
+    {
+        uds_send_negative(response,
+                          UDS_SID_ROUTINE_CTRL,
+                          UDS_NRC_REQUEST_OOR);
+    }
+}
+
+/* ===================================================================
+ * Public API
+ * =================================================================== */
+
+void uds_init(uds_state_t *state)
+{
+    state->aeb_enabled  = 1U;
+    state->dtc_sensor   = 0U;
+    state->dtc_crc      = 0U;
+    state->dtc_actuator = 0U;
+}
+
+void uds_monitor_faults(uds_state_t *state,
+                        uint8_t sensor_fault,
+                        uint8_t crc_error,
+                        uint8_t actuator_fault)
+{
+    /* DD-UDS-01: immediate latch, no debounce. */
+    if (sensor_fault != 0U)
+    {
+        state->dtc_sensor = 1U;
+    }
+
+    if (crc_error != 0U)
+    {
+        state->dtc_crc = 1U;
+    }
+
+    if (actuator_fault != 0U)
+    {
+        state->dtc_actuator = 1U;
+    }
+}
+
+void uds_process_request(uds_state_t *state,
+                         const uds_request_t *request,
+                         uds_response_t *response,
+                         const fsm_output_t *fsm_out,
+                         const pid_output_t *pid_out,
+                         const ttc_output_t *ttc_out)
+{
+    uds_clear_response(response);
+
+    /* Only process if sid is valid (sid != 0) — single exit point (Rule 15.5) */
+    if (request->sid != 0U)
+    {
+        switch (request->sid)
+        {
+            case UDS_SID_READ_DID:          /* 0x22 */
+            {
+                uds_handle_read_did(request, response,
+                                    fsm_out, pid_out, ttc_out);
+                break;
+            }
+
+            case UDS_SID_CLEAR_DTC:         /* 0x14 */
+            {
+                uds_handle_clear_dtc(state, response);
+                break;
+            }
+
+            case UDS_SID_ROUTINE_CTRL:      /* 0x31 */
+            {
+                uds_handle_routine_ctrl(state, request, response);
+                break;
+            }
+
+            default:                        /* NRC 0x11 */
+            {
+                uds_send_negative(response,
+                                  request->sid,
+                                  UDS_NRC_SERVICE_NOT_SUPP);
+                break;
+            }
+        }
+    }
+}
+
+void uds_get_output(const uds_state_t *state, uds_output_t *output)
+{
+    uint8_t count;
+
+    output->aeb_enabled = state->aeb_enabled;
+
+    count = state->dtc_sensor + state->dtc_crc + state->dtc_actuator;
+    output->dtc_count = count;
+
+    if (count > 0U)
+    {
+        output->fault_lamp = 1U;
+    }
+    else
+    {
+        output->fault_lamp = 0U;
+    }
 }

--- a/src/communication/aeb_uds.c
+++ b/src/communication/aeb_uds.c
@@ -2,7 +2,6 @@
  * @file aeb_uds.c
  * @brief UDS Diagnostics server — C translation of Simulink UDS_Server.
  *
- * Direct translation of the MATLAB Function block (chart_117):
  *   - Persistent variables  ->  uds_state_t struct members.
  *   - Immediate DTC latch (DD-UDS-01).
  *   - Scaled integer encoding for DIDs (DD-UDS-03 encoding).
@@ -11,6 +10,7 @@
  *
  * @req FR-UDS-001..005, FR-COD-001, FR-COD-003
  *
+ * @author  Rian Linhares
  * @version 1.0
  * @date 2026-04
  */

--- a/src/communication/aeb_uds.c
+++ b/src/communication/aeb_uds.c
@@ -2,6 +2,7 @@
  * @file aeb_uds.c
  * @brief UDS Diagnostics server — C translation of Simulink UDS_Server.
  *
+ * Direct translation of the MATLAB Function block (chart_117):
  *   - Persistent variables  ->  uds_state_t struct members.
  *   - Immediate DTC latch (DD-UDS-01).
  *   - Scaled integer encoding for DIDs (DD-UDS-03 encoding).
@@ -10,7 +11,6 @@
  *
  * @req FR-UDS-001..005, FR-COD-001, FR-COD-003
  *
- * @author  Rian Linhares
  * @version 1.0
  * @date 2026-04
  */
@@ -70,7 +70,7 @@ static void uds_handle_read_did(const uds_request_t *request,
                                 const ttc_output_t *ttc_out)
 {
     uint16_t requested_id;
-    uint16_t scaled_val;
+    uint16_t scaled_val = 0U;
 
     requested_id = ((uint16_t)request->did_high * 256U)
                  + (uint16_t)request->did_low;

--- a/stubs/zephyr_stub.c
+++ b/stubs/zephyr_stub.c
@@ -1,0 +1,16 @@
+/**
+ * @file zephyr_stub.c
+ * @brief Zephyr RTOS stub implementation for host build.
+ *
+ * Provides minimal implementations needed for host compilation.
+ * No actual Zephyr functionality — testing only.
+ *
+ * @version 1.0
+ * @date 2026-04
+ */
+
+#include "zephyr_stub.h"
+
+/* No functions needed — the UDS module is pure logic
+ * with no direct Zephyr dependencies.
+ * This file exists to satisfy the Makefile link step. */

--- a/stubs/zephyr_stub.h
+++ b/stubs/zephyr_stub.h
@@ -1,0 +1,27 @@
+/**
+ * @file zephyr_stub.h
+ * @brief Minimal Zephyr RTOS stubs for host (PC) compilation and testing.
+ *
+ * Provides empty definitions for Zephyr kernel types and macros
+ * used by aeb_main.c, allowing the UDS module to be compiled and
+ * tested on a host PC with GCC (NFR-POR-001).
+ *
+ * This file is NOT used when compiling for the Zephyr target.
+ *
+ * @version 1.0
+ * @date 2026-04
+ */
+
+#ifndef ZEPHYR_STUB_H
+#define ZEPHYR_STUB_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+/* ===================================================================
+ * printk stub
+ * =================================================================== */
+
+#define printk(fmt, ...)    printf(fmt, ##__VA_ARGS__)
+
+#endif /* ZEPHYR_STUB_H */

--- a/tests/test_uds.c
+++ b/tests/test_uds.c
@@ -1,0 +1,528 @@
+/**
+ * @file test_uds.c
+ * @brief Unit tests for the AEB UDS diagnostics module.
+ *
+ * Native host test runner (GCC + assert). No Zephyr dependency.
+ * Run with: make test
+ *
+ * Test coverage:
+ *   - Initialisation and power-on state.
+ *   - ReadDataByIdentifier (SID 0x22) for all 3 DIDs.
+ *   - ClearDiagnosticInformation (SID 0x14).
+ *   - RoutineControl (SID 0x31, routine 0x0301).
+ *   - DTC monitoring and fault lamp.
+ *   - Negative responses for unsupported SID/DID.
+ *   - Edge cases and boundary values.
+ *
+ * @req FR-UDS-001..005
+ * @req NFR-COD-006 Statement coverage >= 80%.
+ * @req NFR-COD-007 Branch coverage >= 60%.
+ *
+ * @version 1.0
+ * @date 2026-04
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "aeb_uds.h"
+#include "aeb_types.h"
+#include "aeb_config.h"
+
+/* ===================================================================
+ * Test infrastructure
+ * =================================================================== */
+
+static int32_t tests_run    = 0;
+static int32_t tests_passed = 0;
+
+#define RUN_TEST(fn)                                            \
+    do {                                                        \
+        tests_run++;                                            \
+        printf("  [%02d] %-50s ", tests_run, #fn);              \
+        (fn)();                                                 \
+        tests_passed++;                                         \
+        printf("PASS\n");                                       \
+    } while (0)
+
+#define ASSERT_EQ(actual, expected, msg)                        \
+    do {                                                        \
+        if ((actual) != (expected)) {                           \
+            printf("FAIL\n       %s\n"                          \
+                   "       expected: %d  got: %d\n",            \
+                   (msg), (int)(expected), (int)(actual));      \
+            assert((actual) == (expected));                     \
+        }                                                       \
+    } while (0)
+
+/* ===================================================================
+ * Shared test variables
+ * =================================================================== */
+
+static uds_state_t    st;
+static uds_request_t  req;
+static uds_response_t resp;
+static fsm_output_t   fsm;
+static pid_output_t   pid;
+static ttc_output_t   ttc;
+static uds_output_t   out;
+
+/** @brief Reset all test structures. */
+static void reset(void)
+{
+    uds_init(&st);
+    (void)memset(&req,  0, sizeof(req));
+    (void)memset(&resp, 0, sizeof(resp));
+    (void)memset(&fsm,  0, sizeof(fsm));
+    (void)memset(&pid,  0, sizeof(pid));
+    (void)memset(&ttc,  0, sizeof(ttc));
+    (void)memset(&out,  0, sizeof(out));
+}
+
+/* ===================================================================
+ * Tests: Initialisation
+ * =================================================================== */
+
+/** @req NFR-SAF-004 */
+static void test_init_defaults(void)
+{
+    reset();
+    uds_get_output(&st, &out);
+
+    ASSERT_EQ(out.aeb_enabled, 1U, "AEB enabled at power-on");
+    ASSERT_EQ(out.dtc_count,   0U, "No DTCs at power-on");
+    ASSERT_EQ(out.fault_lamp,  0U, "Fault lamp OFF at power-on");
+}
+
+/* ===================================================================
+ * Tests: ReadDataByIdentifier (SID 0x22)
+ * =================================================================== */
+
+/** @req FR-UDS-001 — TTC (DID 0xF100, scaled x100) */
+static void test_read_did_ttc(void)
+{
+    uint16_t ttc_raw;
+
+    reset();
+    ttc.ttc       = 3.45f;
+    req.sid       = UDS_SID_READ_DID;
+    req.did_high  = 0xF1U;
+    req.did_low   = 0x00U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid,  UDS_SID_READ_DID_RESP, "SID 0x62");
+    ASSERT_EQ(resp.did_high_resp, 0xF1U, "DID high echoed");
+    ASSERT_EQ(resp.did_low_resp,  0x00U, "DID low echoed");
+
+    ttc_raw = (uint16_t)resp.data1 | ((uint16_t)resp.data2 << 8U);
+    ASSERT_EQ(ttc_raw, 345U, "TTC = 3.45 * 100 = 345");
+}
+
+/** @req FR-UDS-001 — FSM state (DID 0xF101, raw integer) */
+static void test_read_did_fsm_state(void)
+{
+    reset();
+    fsm.fsm_state = (uint8_t)FSM_BRAKE_L2;
+    req.sid       = UDS_SID_READ_DID;
+    req.did_high  = 0xF1U;
+    req.did_low   = 0x01U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_READ_DID_RESP, "SID 0x62");
+    ASSERT_EQ(resp.data1, (uint8_t)FSM_BRAKE_L2, "FSM = BRAKE_L2 (4)");
+}
+
+/** @req FR-UDS-001 — Brake pressure (DID 0xF102, scaled x10) */
+static void test_read_did_brake_pressure(void)
+{
+    uint16_t p_raw;
+
+    reset();
+    pid.brake_pct = 75.5f;
+    req.sid       = UDS_SID_READ_DID;
+    req.did_high  = 0xF1U;
+    req.did_low   = 0x02U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_READ_DID_RESP, "SID 0x62");
+
+    p_raw = (uint16_t)resp.data1 | ((uint16_t)resp.data2 << 8U);
+    ASSERT_EQ(p_raw, 755U, "Brake = 75.5 * 10 = 755");
+}
+
+/** @req FR-UDS-005 — Unsupported DID -> NRC 0x31 */
+static void test_read_did_unsupported(void)
+{
+    reset();
+    req.sid      = UDS_SID_READ_DID;
+    req.did_high = 0xFFU;
+    req.did_low  = 0xFFU;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid,  UDS_SID_NEGATIVE_RESP, "SID 0x7F");
+    ASSERT_EQ(resp.did_high_resp, UDS_SID_READ_DID, "Rejected SID echoed");
+    ASSERT_EQ(resp.did_low_resp,  UDS_NRC_REQUEST_OOR, "NRC 0x31");
+}
+
+/* ===================================================================
+ * Tests: ClearDiagnosticInformation (SID 0x14)
+ * =================================================================== */
+
+/** @req FR-UDS-003 */
+static void test_clear_dtc(void)
+{
+    reset();
+
+    /* Set all faults */
+    uds_monitor_faults(&st, 1U, 1U, 1U);
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.dtc_count,  3U, "3 DTCs before clear");
+    ASSERT_EQ(out.fault_lamp, 1U, "Lamp ON before clear");
+
+    /* Clear */
+    req.sid = UDS_SID_CLEAR_DTC;
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_CLEAR_DTC_RESP, "SID 0x54");
+
+    /* Readback */
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.dtc_count,  0U, "0 DTCs after clear");
+    ASSERT_EQ(out.fault_lamp, 0U, "Lamp OFF after clear");
+}
+
+/* ===================================================================
+ * Tests: RoutineControl (SID 0x31)
+ * =================================================================== */
+
+/** @req FR-UDS-004 — Disable AEB */
+static void test_routine_disable_aeb(void)
+{
+    reset();
+    req.sid      = UDS_SID_ROUTINE_CTRL;
+    req.did_high = 0x03U;
+    req.did_low  = 0x01U;
+    req.value    = 0U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_ROUTINE_CTRL_RESP, "SID 0x71");
+    ASSERT_EQ(resp.data1, 0U, "data1 = 0 (disabled)");
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.aeb_enabled, 0U, "AEB disabled");
+}
+
+/** @req FR-UDS-004 — Enable AEB */
+static void test_routine_enable_aeb(void)
+{
+    reset();
+    st.aeb_enabled = 0U;
+
+    req.sid      = UDS_SID_ROUTINE_CTRL;
+    req.did_high = 0x03U;
+    req.did_low  = 0x01U;
+    req.value    = 1U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_ROUTINE_CTRL_RESP, "SID 0x71");
+    ASSERT_EQ(resp.data1, 1U, "data1 = 1 (enabled)");
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.aeb_enabled, 1U, "AEB enabled");
+}
+
+/** Invalid value for routine 0x0301 */
+static void test_routine_invalid_value(void)
+{
+    reset();
+    req.sid      = UDS_SID_ROUTINE_CTRL;
+    req.did_high = 0x03U;
+    req.did_low  = 0x01U;
+    req.value    = 5U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_NEGATIVE_RESP, "SID 0x7F");
+}
+
+/** Unsupported routine ID */
+static void test_routine_unsupported_rid(void)
+{
+    reset();
+    req.sid      = UDS_SID_ROUTINE_CTRL;
+    req.did_high = 0xFFU;
+    req.did_low  = 0xFFU;
+    req.value    = 1U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, UDS_SID_NEGATIVE_RESP, "SID 0x7F");
+}
+
+/* ===================================================================
+ * Tests: DTC Monitoring
+ * =================================================================== */
+
+/** @req FR-UDS-002 — Sensor fault (C1001) */
+static void test_dtc_sensor_fault(void)
+{
+    reset();
+    uds_monitor_faults(&st, 1U, 0U, 0U);
+    uds_get_output(&st, &out);
+
+    ASSERT_EQ(out.dtc_count,  1U, "DTC count = 1");
+    ASSERT_EQ(out.fault_lamp, 1U, "Lamp ON");
+}
+
+/** @req FR-UDS-002 — CRC error (C1004) */
+static void test_dtc_crc_error(void)
+{
+    reset();
+    uds_monitor_faults(&st, 0U, 1U, 0U);
+    uds_get_output(&st, &out);
+
+    ASSERT_EQ(out.dtc_count, 1U, "DTC count = 1");
+}
+
+/** @req FR-UDS-002 — Actuator fault (C1006) */
+static void test_dtc_actuator_fault(void)
+{
+    reset();
+    uds_monitor_faults(&st, 0U, 0U, 1U);
+    uds_get_output(&st, &out);
+
+    ASSERT_EQ(out.dtc_count, 1U, "DTC count = 1");
+}
+
+/** @req FR-UDS-002 — Latch persists after fault clears (DD-UDS-01) */
+static void test_dtc_latch_persists(void)
+{
+    reset();
+    uds_monitor_faults(&st, 1U, 0U, 0U);   /* fault ON  */
+    uds_monitor_faults(&st, 0U, 0U, 0U);   /* fault OFF */
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.dtc_count,  1U, "DTC persists");
+    ASSERT_EQ(out.fault_lamp, 1U, "Lamp still ON");
+}
+
+/** All 3 faults simultaneously */
+static void test_dtc_multiple_faults(void)
+{
+    reset();
+    uds_monitor_faults(&st, 1U, 1U, 1U);
+    uds_get_output(&st, &out);
+
+    ASSERT_EQ(out.dtc_count, 3U, "DTC count = 3");
+}
+
+/* ===================================================================
+ * Tests: Negative Responses
+ * =================================================================== */
+
+/** @req FR-UDS-005 — Unsupported SID -> NRC 0x11 */
+static void test_unsupported_sid(void)
+{
+    reset();
+    req.sid = 0xAAU;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid,  UDS_SID_NEGATIVE_RESP, "SID 0x7F");
+    ASSERT_EQ(resp.did_high_resp, 0xAAU, "Rejected SID echoed");
+    ASSERT_EQ(resp.did_low_resp,  UDS_NRC_SERVICE_NOT_SUPP, "NRC 0x11");
+}
+
+/** Empty request (sid=0) -> no response */
+static void test_empty_request(void)
+{
+    reset();
+    req.sid = 0U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.response_sid, 0U, "No response for sid=0");
+}
+
+/* ===================================================================
+ * Tests: Edge Cases
+ * =================================================================== */
+
+/** TTC = 0.0 boundary */
+static void test_ttc_zero(void)
+{
+    uint16_t ttc_raw;
+
+    reset();
+    ttc.ttc      = 0.0f;
+    req.sid      = UDS_SID_READ_DID;
+    req.did_high = 0xF1U;
+    req.did_low  = 0x00U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ttc_raw = (uint16_t)resp.data1 | ((uint16_t)resp.data2 << 8U);
+    ASSERT_EQ(ttc_raw, 0U, "TTC=0 -> 0");
+}
+
+/** TTC = 10.0 (max) boundary */
+static void test_ttc_max(void)
+{
+    uint16_t ttc_raw;
+
+    reset();
+    ttc.ttc      = 10.0f;
+    req.sid      = UDS_SID_READ_DID;
+    req.did_high = 0xF1U;
+    req.did_low  = 0x00U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ttc_raw = (uint16_t)resp.data1 | ((uint16_t)resp.data2 << 8U);
+    ASSERT_EQ(ttc_raw, 1000U, "TTC=10 -> 1000");
+}
+
+/** Brake pressure = 100% boundary */
+static void test_brake_pressure_max(void)
+{
+    uint16_t p_raw;
+
+    reset();
+    pid.brake_pct = 100.0f;
+    req.sid       = UDS_SID_READ_DID;
+    req.did_high  = 0xF1U;
+    req.did_low   = 0x02U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    p_raw = (uint16_t)resp.data1 | ((uint16_t)resp.data2 << 8U);
+    ASSERT_EQ(p_raw, 1000U, "Brake 100%% -> 1000");
+}
+
+/** FSM POST_BRAKE (state 6) readable */
+static void test_fsm_state_post_brake(void)
+{
+    reset();
+    fsm.fsm_state = (uint8_t)FSM_POST_BRAKE;
+    req.sid       = UDS_SID_READ_DID;
+    req.did_high  = 0xF1U;
+    req.did_low   = 0x01U;
+
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    ASSERT_EQ(resp.data1, (uint8_t)FSM_POST_BRAKE, "FSM = 6");
+}
+
+/** @req FR-UDS-004 — aeb_enabled persists across cycles (DD-UDS-02) */
+static void test_enable_disable_cycle(void)
+{
+    reset();
+
+    /* Disable */
+    req.sid      = UDS_SID_ROUTINE_CTRL;
+    req.did_high = 0x03U;
+    req.did_low  = 0x01U;
+    req.value    = 0U;
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.aeb_enabled, 0U, "Disabled");
+
+    /* Empty cycle — persists */
+    req.sid = 0U;
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.aeb_enabled, 0U, "Still disabled");
+
+    /* Re-enable */
+    req.sid      = UDS_SID_ROUTINE_CTRL;
+    req.did_high = 0x03U;
+    req.did_low  = 0x01U;
+    req.value    = 1U;
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.aeb_enabled, 1U, "Re-enabled");
+}
+
+/** Clear DTCs then re-fault — verify re-latch */
+static void test_dtc_clear_then_refault(void)
+{
+    reset();
+
+    uds_monitor_faults(&st, 1U, 0U, 0U);
+
+    req.sid = UDS_SID_CLEAR_DTC;
+    uds_process_request(&st, &req, &resp, &fsm, &pid, &ttc);
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.dtc_count, 0U, "Cleared");
+
+    uds_monitor_faults(&st, 0U, 1U, 0U);
+
+    uds_get_output(&st, &out);
+    ASSERT_EQ(out.dtc_count,  1U, "Re-latched");
+    ASSERT_EQ(out.fault_lamp, 1U, "Lamp ON after re-fault");
+}
+
+/* ===================================================================
+ * Main — test runner
+ * =================================================================== */
+
+int main(void)
+{
+    printf("\n======================================\n");
+    printf("  AEB UDS Module — Unit Tests\n");
+    printf("======================================\n\n");
+
+    /* Initialisation */
+    RUN_TEST(test_init_defaults);
+
+    /* SID 0x22 — ReadDataByIdentifier */
+    RUN_TEST(test_read_did_ttc);
+    RUN_TEST(test_read_did_fsm_state);
+    RUN_TEST(test_read_did_brake_pressure);
+    RUN_TEST(test_read_did_unsupported);
+
+    /* SID 0x14 — ClearDiagnosticInformation */
+    RUN_TEST(test_clear_dtc);
+
+    /* SID 0x31 — RoutineControl */
+    RUN_TEST(test_routine_disable_aeb);
+    RUN_TEST(test_routine_enable_aeb);
+    RUN_TEST(test_routine_invalid_value);
+    RUN_TEST(test_routine_unsupported_rid);
+
+    /* DTC Monitoring */
+    RUN_TEST(test_dtc_sensor_fault);
+    RUN_TEST(test_dtc_crc_error);
+    RUN_TEST(test_dtc_actuator_fault);
+    RUN_TEST(test_dtc_latch_persists);
+    RUN_TEST(test_dtc_multiple_faults);
+
+    /* Negative Responses */
+    RUN_TEST(test_unsupported_sid);
+    RUN_TEST(test_empty_request);
+
+    /* Edge Cases */
+    RUN_TEST(test_ttc_zero);
+    RUN_TEST(test_ttc_max);
+    RUN_TEST(test_brake_pressure_max);
+    RUN_TEST(test_fsm_state_post_brake);
+    RUN_TEST(test_enable_disable_cycle);
+    RUN_TEST(test_dtc_clear_then_refault);
+
+    printf("\n======================================\n");
+    printf("  Results: %d / %d passed\n",
+           (int)tests_passed, (int)tests_run);
+    printf("======================================\n\n");
+
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
# Summary
- Implement full UDS diagnostics server (aeb_uds.c) translated from Simulink UDS_Server (chart_117)
- Support three UDS services: ReadDataByIdentifier (SID 0x22), ClearDiagnosticInformation (SID 0x14), RoutineControl (SID 0x31)
- Live data access for TTC (DID 0xF100), FSM state (DID 0xF101), brake pressure (DID 0xF102)
- DTC monitoring and storage: sensor fault (C1001), CRC error (C1004), actuator fault (C1006)
- AEB enable/disable via routine 0x0301 with persistent state across cycles
- Negative response (0x7F) for unsupported SID (NRC 0x11) and DID (NRC 0x31)
- Enable MISRA C:2012 check on UDS module in CI

# Related Issue
Closes #38 
Ref #39 

# Change Type
- [x] feat
- [ ] fix
- [ ] docs
- [x] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [x] UDS Diagnostics
- [x] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-UDS-001: ReadDataByIdentifier (SID 0x22) for TTC, FSM state, brake pressure
- FR-UDS-002: DTC storage for sensor (C1001), CRC (C1004), actuator (C1006) faults
- FR-UDS-003: ClearDiagnosticInformation (SID 0x14) resets all stored DTCs
- FR-UDS-004: RoutineControl (SID 0x31, routine 0x0301) to enable/disable AEB
- FR-UDS-005: UDS request/response via CAN within one system cycle

## Non-Functional Requirements
- NFR-COD-001: MISRA C:2012 compliance (zero violations)
- NFR-COD-002: No malloc, no recursion, no dynamic function pointers
- NFR-COD-005: Fixed-width types throughout (uint8_t, uint16_t, float32_t)
- NFR-POR-002: Calibration parameters separated in aeb_config.h
- NFR-POR-003: Modular architecture with struct-based interfaces
- NFR-SAF-004: Power-on self-test at initialisation

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [x] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes (`make build` — zero warnings)
- [x] Automated tests pass(`make test` — 23/23)
- [x] CI passes
- [ ] Traceability updated
- [ ] Safety-relevant impact assessed
- [ ] Documentation updated
- [x] MISRA check passes (`make misra`)

## Evidence
```
$ make test
======================================
  AEB UDS Module — Unit Tests
======================================
  [01] test_init_defaults                                 PASS
  [02] test_read_did_ttc                                  PASS
  [03] test_read_did_fsm_state                            PASS
  [04] test_read_did_brake_pressure                       PASS
  [05] test_read_did_unsupported                          PASS
  [06] test_clear_dtc                                     PASS
  [07] test_routine_disable_aeb                           PASS
  [08] test_routine_enable_aeb                            PASS
  [09] test_routine_invalid_value                         PASS
  [10] test_routine_unsupported_rid                       PASS
  [11] test_dtc_sensor_fault                              PASS
  [12] test_dtc_crc_error                                 PASS
  [13] test_dtc_actuator_fault                            PASS
  [14] test_dtc_latch_persists                            PASS
  [15] test_dtc_multiple_faults                           PASS
  [16] test_unsupported_sid                               PASS
  [17] test_empty_request                                 PASS
  [18] test_ttc_zero                                      PASS
  [19] test_ttc_max                                       PASS
  [20] test_brake_pressure_max                            PASS
  [21] test_fsm_state_post_brake                          PASS
  [22] test_enable_disable_cycle                          PASS
  [23] test_dtc_clear_then_refault                        PASS
======================================
  Results: 23 / 23 passed
======================================

$ make cppcheck
Checking src\aeb_uds.c ...
(only shared-header advisories — zero violations in aeb_uds.c)
```

# Reviewer Notes
- DID encoding follows UDS.dbc message definition (Request ID 0x7DF, Response ID 0x7E8)
- Design decisions documented: DD-UDS-01 (immediate DTC latch), DD-UDS-02 (persistent aeb_enabled), DD-UDS-03 (negative response handling)
- Module communicates via typed structs (uds_request_t, uds_response_t); CAN transport handled by Task D (aeb_can.c)
- `stubs/zephyr_stub.*` abstracts the Zephyr CAN driver for host testing

# Risks / Open Points
List known limitations, assumptions, or follow-up actions.
