### PR TITLE
Feat/decision ttc fsm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: AEB CI — Build, Test & MISRA Check
+
+on:
+  pull_request:
+    branches: [development]
+  push:
+    branches: [development]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: Build (zero-warning gate)
+        run: make build
+
+      - name: Run unit tests
+        run: make test
+
+      - name: MISRA C:2012 check (cppcheck)
+        run: make misra

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Build artefacts
+*.o
+*.exe
+test_smoke
+test_can
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS
+Thumbs.db
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ SRC_ALL = src/communication/aeb_can.c \
 # Smoke test (baseline — always present)
 SRC_SMOKE = src/communication/aeb_can.c stubs/can_hal.c tests/test_smoke.c
 
+# CAN module tests (Task D)
+SRC_CAN_TEST = src/communication/aeb_can.c stubs/can_hal.c tests/test_can.c
+
 # Real module sources for MISRA check (add files here as stubs are replaced)
-SRC_MISRA =
+SRC_MISRA = src/communication/aeb_can.c
 
 .PHONY: build test misra clean
 
@@ -32,10 +35,14 @@ build:
 	$(CC) $(CFLAGS) -c $(SRC_ALL)
 	@echo "=== Build OK: zero warnings ==="
 
-test: test_smoke
+test: test_smoke test_can
 	./test_smoke
+	./test_can
 
 test_smoke: $(SRC_SMOKE)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_can: $(SRC_CAN_TEST)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 misra:
@@ -47,3 +54,5 @@ endif
 
 clean:
 	rm -f test_smoke test_can *.o
+
+.PHONY: test_can

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Makefile — AEB Stellantis Project (host build)
+#
+# Targets:
+#   make build     — compile all modules (zero-warning gate)
+#   make test      — build and run unit tests
+#   make misra     — run cppcheck MISRA C:2012 on non-stub sources
+#   make clean     — remove build artefacts
+
+CC       = gcc
+CFLAGS   = -Wall -Wextra -Wpedantic -std=c99 -O2 -Iinclude -Istubs
+LDFLAGS  = -lm
+
+# All sources (stubs + real code)
+SRC_ALL = src/communication/aeb_can.c \
+          src/communication/aeb_uds.c \
+          src/perception/aeb_perception.c \
+          src/decision/aeb_ttc.c \
+          src/decision/aeb_fsm.c \
+          src/execution/aeb_pid.c \
+          src/execution/aeb_alert.c \
+          stubs/can_hal.c
+
+# Smoke test (baseline — always present)
+SRC_SMOKE = src/communication/aeb_can.c stubs/can_hal.c tests/test_smoke.c
+
+# Real module sources for MISRA check (add files here as stubs are replaced)
+SRC_MISRA =
+
+.PHONY: build test misra clean
+
+build:
+	$(CC) $(CFLAGS) -c $(SRC_ALL)
+	@echo "=== Build OK: zero warnings ==="
+
+test: test_smoke
+	./test_smoke
+
+test_smoke: $(SRC_SMOKE)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+misra:
+ifneq ($(SRC_MISRA),)
+	cppcheck --addon=misra --std=c99 -Iinclude -Istubs --suppress=unusedFunction --suppress=missingIncludeSystem --enable=all $(SRC_MISRA)
+else
+	@echo "=== No real modules to check yet (all stubs) ==="
+endif
+
+clean:
+	rm -f test_smoke test_can *.o

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -5,7 +5,7 @@
  * Implements FR-CAN-001..004 from the AEB SRS v2.0.
  * Designed for Zephyr RTOS CAN driver; MISRA C:2012 compliant.
  *
- * @author  Renato Fagundes (Task D)
+ * @author  Renato Fagundes
  * @date    2026-04-07
  */
 

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -1,0 +1,206 @@
+/**
+ * @file  aeb_can.h
+ * @brief CAN Bus Communication module — public API.
+ *
+ * Implements FR-CAN-001..004 from the AEB SRS v2.0.
+ * Designed for Zephyr RTOS CAN driver; MISRA C:2012 compliant.
+ *
+ * @author  Renato Fagundes (Task D)
+ * @date    2026-04-07
+ */
+
+#ifndef AEB_CAN_H
+#define AEB_CAN_H
+
+#include "aeb_types.h"
+#include "aeb_config.h"
+#include <stdint.h>
+
+/* ── CAN Message IDs (from aeb_system.dbc) ───────────────────────────── */
+#define CAN_ID_BRAKE_CMD      (0x080U)   /**< 128 — AEB_BrakeCmd  TX     */
+#define CAN_ID_EGO_VEHICLE    (0x100U)   /**< 256 — AEB_EgoVehicle RX    */
+#define CAN_ID_DRIVER_INPUT   (0x101U)   /**< 257 — AEB_DriverInput RX   */
+#define CAN_ID_RADAR_TARGET   (0x120U)   /**< 288 — AEB_RadarTarget RX   */
+#define CAN_ID_FSM_STATE      (0x200U)   /**< 512 — AEB_FSMState TX      */
+#define CAN_ID_ALERT          (0x300U)   /**< 768 — AEB_Alert TX         */
+
+/* ── CAN Frame Lengths (bytes) ───────────────────────────────────────── */
+#define CAN_DLC_BRAKE_CMD     (4U)
+#define CAN_DLC_EGO_VEHICLE   (8U)
+#define CAN_DLC_DRIVER_INPUT  (4U)
+#define CAN_DLC_RADAR_TARGET  (8U)
+#define CAN_DLC_FSM_STATE     (4U)
+#define CAN_DLC_ALERT         (2U)
+
+/* ── RX Timeout ──────────────────────────────────────────────────────── */
+#define CAN_RX_TIMEOUT_CYCLES (3U)  /**< 3 missed frames → fault        */
+
+/* ── Alive counter ───────────────────────────────────────────────────── */
+#define ALIVE_COUNTER_MAX     (15U) /**< 4-bit rolling counter 0..15     */
+
+/* ── Return codes ────────────────────────────────────────────────────── */
+#define CAN_OK                (0)
+#define CAN_ERR_INIT          (-1)
+#define CAN_ERR_TX            (-2)
+#define CAN_ERR_TIMEOUT       (-3)
+
+/**
+ * @brief Raw sensor data decoded from CAN RX frames.
+ *
+ * Populated by can_rx_process() from AEB_EgoVehicle (0x100) and
+ * AEB_RadarTarget (0x120).  Consumed by Task A (Perception).
+ */
+typedef struct
+{
+    /* From AEB_RadarTarget (0x120) */
+    float32_t target_distance;   /**< [m]                                */
+    float32_t relative_speed;    /**< [m/s]                              */
+    float32_t ttc_radar;         /**< [s]   (info only)                  */
+    uint8_t   confidence_raw;    /**< 0..15                              */
+
+    /* From AEB_EgoVehicle (0x100) */
+    float32_t vehicle_speed;     /**< [m/s]                              */
+    float32_t long_accel;        /**< [m/s^2]                            */
+    float32_t yaw_rate;          /**< [deg/s]                            */
+    float32_t steering_angle;    /**< [deg]                              */
+
+    /* From AEB_DriverInput (0x101) */
+    uint8_t   brake_pedal;       /**< [%] 0..100                         */
+    uint8_t   accel_pedal;       /**< [%] 0..100                         */
+    uint8_t   aeb_enable;        /**< 0/1                                */
+    uint8_t   driver_override;   /**< 0/1                                */
+
+    /* Status */
+    uint8_t   rx_timeout_flag;   /**< 1 if radar RX timed out            */
+} can_rx_data_t;
+
+/**
+ * @brief Internal state of the CAN module (opaque to other modules).
+ */
+typedef struct
+{
+    uint8_t   alive_counter;       /**< 4-bit TX rolling counter         */
+    uint8_t   rx_miss_count;       /**< Consecutive missed RX frames     */
+    uint32_t  tx_cycle_counter;    /**< Counts 10 ms ticks for 50 ms TX  */
+    uint8_t   initialised;         /**< 1 after successful can_init()    */
+    can_rx_data_t  last_rx;        /**< Most recent decoded RX data      */
+} can_state_t;
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PUBLIC API
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Initialise CAN peripheral at 500 kbit/s and register RX filters.
+ *
+ * @param[out] state  Module state, zeroed before first call.
+ * @return CAN_OK on success, CAN_ERR_INIT on failure.
+ *
+ * @req FR-CAN-004  Baud rate 500 kbit/s.
+ */
+int32_t can_init(can_state_t *state);
+
+/**
+ * @brief Process a single received CAN frame (called from RX callback).
+ *
+ * Decodes EgoVehicle (0x100) or RadarTarget (0x120) per DBC layout.
+ * Resets the RX miss counter on valid frame.
+ *
+ * @param[in,out] state  Module state.
+ * @param[in]     id     CAN message ID.
+ * @param[in]     data   Pointer to frame payload (up to 8 bytes).
+ * @param[in]     dlc    Data Length Code.
+ *
+ * @req FR-CAN-002  Receive radar target data.
+ * @req FR-CAN-003  DBC signal encoding.
+ */
+void can_rx_process(can_state_t *state,
+                    uint32_t     id,
+                    const uint8_t *data,
+                    uint8_t      dlc);
+
+/**
+ * @brief Check RX timeout — call once per 10 ms cycle.
+ *
+ * Increments miss counter; sets rx_timeout_flag after 3 consecutive
+ * misses (≥ 60 ms with 20 ms radar period).
+ *
+ * @param[in,out] state  Module state.
+ *
+ * @req FR-CAN-002  Timeout detection (acceptance: 3 × 20 ms = 60 ms).
+ */
+void can_check_timeout(can_state_t *state);
+
+/**
+ * @brief Transmit AEB_BrakeCmd (0x080) — every 10 ms cycle.
+ *
+ * @param[in,out] state    Module state (alive counter incremented).
+ * @param[in]     pid_out  PID brake output from Task C.
+ * @param[in]     fsm_out  FSM output from Task B.
+ * @return CAN_OK on success, CAN_ERR_TX on failure.
+ *
+ * @req FR-CAN-003  DBC signal encoding.
+ */
+int32_t can_tx_brake_cmd(can_state_t       *state,
+                         const pid_output_t *pid_out,
+                         const fsm_output_t *fsm_out);
+
+/**
+ * @brief Transmit AEB_FSMState (0x200) — every 50 ms (5 × 10 ms ticks).
+ *
+ * @param[in,out] state    Module state (cycle counter checked).
+ * @param[in]     fsm_out  FSM output from Task B.
+ * @return CAN_OK if transmitted, 1 if not yet due, CAN_ERR_TX on failure.
+ *
+ * @req FR-CAN-001  Transmit ego dynamics at fixed cycle.
+ */
+int32_t can_tx_fsm_state(can_state_t       *state,
+                         const fsm_output_t *fsm_out);
+
+/**
+ * @brief Transmit AEB_Alert (0x300) — event-driven, call when alert changes.
+ *
+ * @param[in] alert_out  Alert output from Task C.
+ * @return CAN_OK on success, CAN_ERR_TX on failure.
+ *
+ * @req FR-CAN-003  DBC signal encoding.
+ */
+int32_t can_tx_alert(const alert_output_t *alert_out);
+
+/**
+ * @brief Get a copy of the latest decoded RX data.
+ *
+ * @param[in]  state  Module state.
+ * @param[out] out    Destination struct.
+ */
+void can_get_rx_data(const can_state_t *state,
+                     can_rx_data_t     *out);
+
+/* ── Signal encode/decode helpers (FR-CAN-003) ───────────────────────── */
+
+/**
+ * @brief Pack an unsigned integer signal into a CAN frame payload.
+ *
+ * @param[out] data       Frame payload buffer.
+ * @param[in]  start_bit  LSB bit position (Intel / little-endian).
+ * @param[in]  length     Signal length in bits (1..32).
+ * @param[in]  raw_value  Unsigned raw value to pack.
+ */
+void can_pack_signal(uint8_t *data,
+                     uint8_t  start_bit,
+                     uint8_t  length,
+                     uint32_t raw_value);
+
+/**
+ * @brief Unpack an unsigned integer signal from a CAN frame payload.
+ *
+ * @param[in]  data       Frame payload buffer.
+ * @param[in]  start_bit  LSB bit position (Intel / little-endian).
+ * @param[in]  length     Signal length in bits (1..32).
+ * @return Unsigned raw value.
+ */
+uint32_t can_unpack_signal(const uint8_t *data,
+                           uint8_t        start_bit,
+                           uint8_t        length);
+
+#endif /* AEB_CAN_H */

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -1,0 +1,44 @@
+/**
+ * @file  aeb_config.h
+ * @brief Calibration parameters for the AEB system (NFR-POR-002).
+ *
+ * Only the CAN-relevant subset is included here for Task D compilation.
+ * Full file maintained by Task E (Rian).
+ */
+
+#ifndef AEB_CONFIG_H
+#define AEB_CONFIG_H
+
+/* Timing */
+#define AEB_CYCLE_TIME_MS     10U        /**< 100 Hz                  */
+#define AEB_DT                0.01F      /**< 10 ms in seconds        */
+
+/* TTC thresholds (FR-DEC-004) */
+#define TTC_WARNING           4.0F       /**< s                       */
+#define TTC_BRAKE_L1          3.0F       /**< s                       */
+#define TTC_BRAKE_L2          2.2F       /**< s                       */
+#define TTC_BRAKE_L3          1.8F       /**< s                       */
+#define TTC_MAX               10.0F      /**< s — saturation          */
+#define V_REL_MIN             0.5F       /**< m/s                     */
+
+/* Speed range (FR-DEC-008) */
+#define V_EGO_MIN             2.78F      /**< m/s = 10 km/h           */
+#define V_EGO_MAX             16.67F     /**< m/s = 60 km/h           */
+
+/* Deceleration levels */
+#define DECEL_L1              2.0F       /**< m/s^2                   */
+#define DECEL_L2              4.0F       /**< m/s^2                   */
+#define DECEL_L3              6.0F       /**< m/s^2 (= amax)          */
+
+/* CAN (FR-CAN) */
+#define CAN_BAUD_RATE         500000U    /**< 500 kbit/s              */
+#define CAN_TX_PERIOD_MS      50U        /**< ego dynamics TX period  */
+#define CAN_RX_TIMEOUT_MS     60U        /**< 3 × 20 ms              */
+
+/* UDS DIDs */
+#define UDS_DID_TTC           0xF100U
+#define UDS_DID_FSM_STATE     0xF101U
+#define UDS_DID_BRAKE_PRESS   0xF102U
+#define UDS_ROUTINE_AEB       0x0301U
+
+#endif /* AEB_CONFIG_H */

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -2,7 +2,7 @@
  * @file  aeb_config.h
  * @brief Calibration parameters for the AEB system (NFR-POR-002).
  *
- * Only the CAN-relevant subset is included here for Task D compilation.
+ * CAN-relevant subset of calibration parameters.
  * Full file maintained by Task E (Rian).
  */
 

--- a/include/aeb_fsm.h
+++ b/include/aeb_fsm.h
@@ -1,0 +1,37 @@
+/**
+ * @file aeb_fsm.h
+ * @brief 7-state Autonomous Emergency Braking Finite State Machine.
+ * @author Lourenço Jamba Mphili
+ * @requirements FR-FSM-001 to FR-FSM-006, FR-DEC-004 to FR-DEC-011
+ */
+
+#ifndef AEB_FSM_H
+#define AEB_FSM_H
+
+#include <stdint.h>
+#include "aeb_types.h"
+#include "aeb_config.h"
+
+/**
+ * @brief Initialize FSM internal state.
+ * @param fsm_out Pointer to FSM output structure
+ * @requirement FR-FSM-001 (Initial state = STANDBY)
+ */
+void fsm_init(fsm_output_t * const fsm_out);
+
+/**
+ * @brief Execute one step of the AEB FSM.
+ * @param delta_t_s Time elapsed since last call [s] (typically AEB_DT = 0.01s)
+ * @param perception Input from perception module
+ * @param driver Input from driver inputs
+ * @param ttc_in Precomputed TTC results
+ * @param fsm_out Current/next FSM state (updated in-place)
+ * @requirement FR-FSM-002, FR-FSM-003, FR-FSM-004, FR-FSM-005, FR-FSM-006
+ */
+void fsm_step(float32_t delta_t_s,
+              const perception_output_t * const perception,
+              const driver_input_t * const driver,
+              const ttc_output_t * const ttc_in,
+              fsm_output_t * const fsm_out);
+
+#endif /* AEB_FSM_H */

--- a/include/aeb_ttc.h
+++ b/include/aeb_ttc.h
@@ -1,0 +1,41 @@
+/**
+ * @file aeb_ttc.h
+ * @brief TTC (Time-to-Collision) and braking distance calculation.
+ * @author Lourenço Jamba Mphili
+ * @requirements FR-DEC-001, FR-DEC-002, FR-DEC-003
+ */
+
+#ifndef AEB_TTC_H
+#define AEB_TTC_H
+
+#include <stdint.h>
+#include "aeb_types.h"
+#include "aeb_config.h"
+
+/**
+ * @brief Calculates Time-to-Collision.
+ * @param distance Distance to target [m]
+ * @param v_rel Relative velocity (ego - target) [m/s]
+ * @return TTC clamped to [0, TTC_MAX] seconds
+ * @requirement FR-DEC-001
+ */
+float32_t ttc_calc(float32_t distance, float32_t v_rel);
+
+/**
+ * @brief Calculates minimum braking distance.
+ * @param v_ego Ego vehicle speed [m/s]
+ * @return d_brake = v² / (2 * DECEL_L3) [m]
+ * @requirement FR-DEC-002
+ */
+float32_t d_brake_calc(float32_t v_ego);
+
+/**
+ * @brief Processes perception data and fills TTC output.
+ * @param perception Input from perception module (contains distance, v_ego, v_rel)
+ * @param ttc_out Output structure (defined in aeb_types.h)
+ * @requirement FR-DEC-003
+ */
+void ttc_process(const perception_output_t * const perception,
+                 ttc_output_t * const ttc_out);
+
+#endif /* AEB_TTC_H */

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -1,0 +1,82 @@
+/**
+ * @file  aeb_types.h
+ * @brief Shared interface structs for the AEB system.
+ *
+ * This file is the integration contract between all modules.
+ * Based on AEB_Tasks v1.0 Section 3.1.
+ */
+
+#ifndef AEB_TYPES_H
+#define AEB_TYPES_H
+
+#include <stdint.h>
+
+/** @brief 32-bit IEEE-754 floating-point type (MISRA fixed-width). */
+typedef float float32_t;
+
+/** @brief Perception output (Task A -> Task B). */
+typedef struct
+{
+    float32_t distance;       /**< [0, 300] m              */
+    float32_t v_ego;          /**< m/s                     */
+    float32_t v_rel;          /**< m/s (>0 = closing)      */
+    float32_t confidence;     /**< [0.0, 1.0]              */
+    uint8_t   fault_flag;     /**< 0=OK, 1=fault           */
+} perception_output_t;
+
+/** @brief TTC calculation output (Task B internal). */
+typedef struct
+{
+    float32_t ttc;            /**< [0, 10] s               */
+    float32_t d_brake;        /**< m                       */
+    uint8_t   is_closing;     /**< boolean                 */
+} ttc_output_t;
+
+/** @brief FSM output (Task B -> Tasks C, D, E). */
+typedef struct
+{
+    uint8_t   fsm_state;      /**< 0=OFF .. 6=POST_BRAKE   */
+    float32_t decel_target;   /**< m/s^2                   */
+    uint8_t   brake_active;   /**< boolean                 */
+    uint8_t   alert_level;    /**< 0=none .. 3=critical    */
+    float32_t warn_timer;     /**< s                       */
+    float32_t state_timer;    /**< s                       */
+} fsm_output_t;
+
+/** @brief PID brake output (Task C -> Task D TX). */
+typedef struct
+{
+    float32_t brake_pct;      /**< [0, 100] %              */
+    float32_t brake_bar;      /**< [0, 10] bar             */
+} pid_output_t;
+
+/** @brief Alert output (Task C -> GPIO). */
+typedef struct
+{
+    uint8_t   alert_type;     /**< 0=NONE,1=VIS,2=AUD,3=BOTH */
+    uint8_t   alert_active;   /**< boolean                 */
+    uint8_t   buzzer_cmd;     /**< 0..4 (beep pattern)     */
+} alert_output_t;
+
+/** @brief Driver inputs (Task D RX -> Tasks B, C). */
+typedef struct
+{
+    uint8_t   brake_pedal;    /**< boolean                 */
+    uint8_t   accel_pedal;    /**< boolean                 */
+    float32_t steering_angle; /**< degrees                 */
+    uint8_t   aeb_enabled;    /**< boolean                 */
+} driver_input_t;
+
+/** @brief FSM state enumeration. */
+typedef enum
+{
+    FSM_OFF        = 0,
+    FSM_STANDBY    = 1,
+    FSM_WARNING    = 2,
+    FSM_BRAKE_L1   = 3,
+    FSM_BRAKE_L2   = 4,
+    FSM_BRAKE_L3   = 5,
+    FSM_POST_BRAKE = 6
+} fsm_state_e;
+
+#endif /* AEB_TYPES_H */

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -43,7 +43,7 @@ typedef struct
     float32_t state_timer;    /**< s                       */
 } fsm_output_t;
 
-/** @brief PID brake output (Task C -> Task D TX). */
+/** @brief PID brake output (PID brake -> CAN TX). */
 typedef struct
 {
     float32_t brake_pct;      /**< [0, 100] %              */
@@ -58,7 +58,7 @@ typedef struct
     uint8_t   buzzer_cmd;     /**< 0..4 (beep pattern)     */
 } alert_output_t;
 
-/** @brief Driver inputs (Task D RX -> Tasks B, C). */
+/** @brief Driver inputs (CAN RX -> Decision, Execution). */
 typedef struct
 {
     uint8_t   brake_pedal;    /**< boolean                 */

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -1,0 +1,90 @@
+/**
+ * @file  aeb_can.c
+ * @brief CAN Bus Communication — STUB (Task D placeholder).
+ *
+ * This file will be replaced by Renato's implementation.
+ * Provides empty function bodies so the project compiles and CI passes.
+ */
+
+#include "aeb_can.h"
+#include "can_hal.h"
+#include <string.h>
+
+void can_pack_signal(uint8_t *data,
+                     uint8_t  start_bit,
+                     uint8_t  length,
+                     uint32_t raw_value)
+{
+    (void)data;
+    (void)start_bit;
+    (void)length;
+    (void)raw_value;
+}
+
+uint32_t can_unpack_signal(const uint8_t *data,
+                           uint8_t        start_bit,
+                           uint8_t        length)
+{
+    (void)data;
+    (void)start_bit;
+    (void)length;
+    return 0U;
+}
+
+int32_t can_init(can_state_t *state)
+{
+    if (state != (void *)0)
+    {
+        (void)memset(state, 0, sizeof(can_state_t));
+    }
+    return CAN_OK;
+}
+
+void can_rx_process(can_state_t *state,
+                    uint32_t id,
+                    const uint8_t *data,
+                    uint8_t dlc)
+{
+    (void)state;
+    (void)id;
+    (void)data;
+    (void)dlc;
+}
+
+void can_check_timeout(can_state_t *state)
+{
+    (void)state;
+}
+
+int32_t can_tx_brake_cmd(can_state_t *state,
+                         const pid_output_t *pid_out,
+                         const fsm_output_t *fsm_out)
+{
+    (void)state;
+    (void)pid_out;
+    (void)fsm_out;
+    return CAN_OK;
+}
+
+int32_t can_tx_fsm_state(can_state_t *state,
+                         const fsm_output_t *fsm_out)
+{
+    (void)state;
+    (void)fsm_out;
+    return 1;
+}
+
+int32_t can_tx_alert(const alert_output_t *alert_out)
+{
+    (void)alert_out;
+    return CAN_OK;
+}
+
+void can_get_rx_data(const can_state_t *state,
+                     can_rx_data_t *out)
+{
+    if ((state != (void *)0) && (out != (void *)0))
+    {
+        (void)memcpy(out, &state->last_rx, sizeof(can_rx_data_t));
+    }
+}

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -1,89 +1,460 @@
 /**
  * @file  aeb_can.c
- * @brief CAN Bus Communication — STUB (Task D placeholder).
+ * @brief CAN Bus Communication module — implementation.
  *
- * This file will be replaced by Renato's implementation.
- * Provides empty function bodies so the project compiles and CI passes.
+ * Covers FR-CAN-001..004 from SRS v2.0.
+ * All signal layouts match aeb_system.dbc.
+ * MISRA C:2012 compliant: no malloc, no recursion, fixed-width types,
+ * all variables initialised, single return per function (preferred),
+ * bounded loops, default in every switch.
+ *
+ * @author  Renato Fagundes
+ * @date    2026-04-07
  */
 
 #include "aeb_can.h"
-#include "can_hal.h"
+#include "can_hal.h"   /* Zephyr CAN HAL stub / real driver */
 #include <string.h>
 
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PRIVATE HELPERS — Signal pack / unpack  (FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Pack an unsigned raw value into a little-endian CAN payload.
+ */
 void can_pack_signal(uint8_t *data,
                      uint8_t  start_bit,
                      uint8_t  length,
                      uint32_t raw_value)
 {
-    (void)data;
-    (void)start_bit;
-    (void)length;
-    (void)raw_value;
+    uint8_t bit_idx = 0U;
+
+    for (bit_idx = 0U; bit_idx < length; bit_idx++)
+    {
+        uint8_t  abs_bit  = start_bit + bit_idx;
+        uint8_t  byte_pos = abs_bit / 8U;
+        uint8_t  bit_pos  = abs_bit % 8U;
+        uint8_t  bit_val  = (uint8_t)((raw_value >> bit_idx) & 1U);
+
+        /* Clear then set the target bit */
+        data[byte_pos] = (uint8_t)(data[byte_pos] & (uint8_t)(~(1U << bit_pos)));
+        data[byte_pos] = (uint8_t)(data[byte_pos] | (uint8_t)(bit_val << bit_pos));
+    }
 }
 
+/**
+ * @brief Unpack an unsigned raw value from a little-endian CAN payload.
+ */
 uint32_t can_unpack_signal(const uint8_t *data,
                            uint8_t        start_bit,
                            uint8_t        length)
 {
-    (void)data;
-    (void)start_bit;
-    (void)length;
-    return 0U;
+    uint32_t result  = 0U;
+    uint8_t  bit_idx = 0U;
+
+    for (bit_idx = 0U; bit_idx < length; bit_idx++)
+    {
+        uint8_t  abs_bit  = start_bit + bit_idx;
+        uint8_t  byte_pos = abs_bit / 8U;
+        uint8_t  bit_pos  = abs_bit % 8U;
+        uint8_t  bit_val  = (uint8_t)((data[byte_pos] >> bit_pos) & 1U);
+
+        result |= ((uint32_t)bit_val << bit_idx);
+    }
+
+    return result;
 }
 
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PRIVATE — Physical-to-raw / raw-to-physical conversions
+ *
+ *  DBC formula: physical = raw * factor + offset
+ *  Encode:      raw = (physical - offset) / factor
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+static uint32_t encode_unsigned(float32_t physical,
+                                float32_t factor,
+                                float32_t offset)
+{
+    float32_t raw_f = (physical - offset) / factor;
+    uint32_t  raw   = 0U;
+
+    if (raw_f < 0.0F)
+    {
+        raw = 0U;
+    }
+    else
+    {
+        raw = (uint32_t)(raw_f + 0.5F);  /* round to nearest */
+    }
+
+    return raw;
+}
+
+static float32_t decode_unsigned(uint32_t  raw,
+                                 float32_t factor,
+                                 float32_t offset)
+{
+    return ((float32_t)raw * factor) + offset;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PRIVATE — CRC-4 computation for BrakeCmd alive monitoring
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+static uint8_t compute_crc4(const uint8_t *data, uint8_t len)
+{
+    uint8_t crc = 0x0FU;   /* Initial value, all ones for 4-bit CRC */
+    uint8_t i   = 0U;
+
+    for (i = 0U; i < len; i++)
+    {
+        uint8_t j = 0U;
+
+        crc ^= (data[i] & 0x0FU);
+        for (j = 0U; j < 4U; j++)
+        {
+            if ((crc & 0x08U) != 0U)
+            {
+                crc = (uint8_t)((crc << 1U) ^ 0x03U);  /* Poly x^4+x+1 */
+            }
+            else
+            {
+                crc = (uint8_t)(crc << 1U);
+            }
+            crc &= 0x0FU;
+        }
+
+        crc ^= ((data[i] >> 4U) & 0x0FU);
+        for (j = 0U; j < 4U; j++)
+        {
+            if ((crc & 0x08U) != 0U)
+            {
+                crc = (uint8_t)((crc << 1U) ^ 0x03U);
+            }
+            else
+            {
+                crc = (uint8_t)(crc << 1U);
+            }
+            crc &= 0x0FU;
+        }
+    }
+
+    return crc;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  PUBLIC API
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Initialise CAN driver at 500 kbit/s, register RX filters.
+ * @req FR-CAN-004
+ */
 int32_t can_init(can_state_t *state)
 {
-    if (state != (void *)0)
+    int32_t result = CAN_OK;
+
+    /* Zero the entire state */
+    (void)memset(state, 0, sizeof(can_state_t));
+
+    /* Initialise CAN peripheral via HAL */
+    if (can_hal_init(CAN_BAUD_500K) != 0)
     {
-        (void)memset(state, 0, sizeof(can_state_t));
+        result = CAN_ERR_INIT;
     }
-    return CAN_OK;
+    else
+    {
+        /* Register RX filters for the three messages we receive */
+        (void)can_hal_add_rx_filter(CAN_ID_EGO_VEHICLE);
+        (void)can_hal_add_rx_filter(CAN_ID_DRIVER_INPUT);
+        (void)can_hal_add_rx_filter(CAN_ID_RADAR_TARGET);
+
+        state->initialised = 1U;
+    }
+
+    return result;
 }
 
-void can_rx_process(can_state_t *state,
-                    uint32_t id,
+/**
+ * @brief Decode a received CAN frame into the internal RX struct.
+ * @req FR-CAN-002, FR-CAN-003
+ */
+void can_rx_process(can_state_t   *state,
+                    uint32_t       id,
                     const uint8_t *data,
-                    uint8_t dlc)
+                    uint8_t        dlc)
 {
-    (void)state;
-    (void)id;
-    (void)data;
-    (void)dlc;
+    if ((state != NULL) && (data != NULL))
+    {
+    if (id == CAN_ID_EGO_VEHICLE)
+    {
+        if (dlc >= CAN_DLC_EGO_VEHICLE)
+        {
+            /* VehicleSpeed:  bits 0..15, factor 0.01, offset 0 */
+            uint32_t raw_spd = can_unpack_signal(data, 0U, 16U);
+            state->last_rx.vehicle_speed = decode_unsigned(raw_spd, 0.01F, 0.0F);
+
+            /* LongAccel:  bits 16..31, factor 0.001, offset -32
+             * DBC @1+ = unsigned raw with offset */
+            uint32_t raw_acc = can_unpack_signal(data, 16U, 16U);
+            state->last_rx.long_accel = decode_unsigned(raw_acc, 0.001F, -32.0F);
+
+            /* YawRate:  bits 32..47, factor 0.01, offset -327.68 */
+            uint32_t raw_yaw = can_unpack_signal(data, 32U, 16U);
+            state->last_rx.yaw_rate = decode_unsigned(raw_yaw, 0.01F, -327.68F);
+
+            /* SteeringAngle:  bits 48..63, factor 0.1, offset -3276.8 */
+            uint32_t raw_str = can_unpack_signal(data, 48U, 16U);
+            state->last_rx.steering_angle = decode_unsigned(raw_str, 0.1F, -3276.8F);
+        }
+    }
+    else if (id == CAN_ID_DRIVER_INPUT)
+    {
+        if (dlc >= CAN_DLC_DRIVER_INPUT)
+        {
+            /* BrakePedal:  bits 0..7, factor 1, offset 0 */
+            uint32_t raw_bp = can_unpack_signal(data, 0U, 8U);
+            state->last_rx.brake_pedal = (uint8_t)raw_bp;
+
+            /* AccelPedal:  bits 8..15, factor 1, offset 0 */
+            uint32_t raw_ap = can_unpack_signal(data, 8U, 8U);
+            state->last_rx.accel_pedal = (uint8_t)raw_ap;
+
+            /* AEB_Enable:  bit 16, 1 bit */
+            uint32_t raw_en = can_unpack_signal(data, 16U, 1U);
+            state->last_rx.aeb_enable = (uint8_t)raw_en;
+
+            /* DriverOverride:  bit 17, 1 bit */
+            uint32_t raw_ov = can_unpack_signal(data, 17U, 1U);
+            state->last_rx.driver_override = (uint8_t)raw_ov;
+        }
+    }
+    else if (id == CAN_ID_RADAR_TARGET)
+    {
+        if (dlc >= CAN_DLC_RADAR_TARGET)
+        {
+            /* TargetDistance:  bits 0..15, factor 0.01, offset 0 */
+            uint32_t raw_dist = can_unpack_signal(data, 0U, 16U);
+            state->last_rx.target_distance = decode_unsigned(raw_dist, 0.01F, 0.0F);
+
+            /* RelativeSpeed:  bits 16..31, factor 0.01, offset -327.68
+             * DBC @1+ = unsigned raw with offset */
+            uint32_t raw_vrel = can_unpack_signal(data, 16U, 16U);
+            state->last_rx.relative_speed = decode_unsigned(raw_vrel, 0.01F, -327.68F);
+
+            /* TTC:  bits 32..47, factor 0.001, offset 0 */
+            uint32_t raw_ttc = can_unpack_signal(data, 32U, 16U);
+            state->last_rx.ttc_radar = decode_unsigned(raw_ttc, 0.001F, 0.0F);
+
+            /* Confidence:  bits 48..55, factor 1, offset 0 */
+            uint32_t raw_conf = can_unpack_signal(data, 48U, 8U);
+            state->last_rx.confidence_raw = (uint8_t)raw_conf;
+
+            /* Valid frame received — reset miss counter */
+            state->rx_miss_count = 0U;
+            state->last_rx.rx_timeout_flag = 0U;
+        }
+    }
+    else
+    {
+        /* Unknown ID — ignore (MISRA: all paths handled) */
+    }
+    } /* end null guard */
 }
 
+/**
+ * @brief Check for RX timeout.  Call once per 10 ms tick.
+ * @req FR-CAN-002 (timeout: 3 × 20 ms = 60 ms)
+ */
 void can_check_timeout(can_state_t *state)
 {
-    (void)state;
+    if (state != NULL)
+    {
+    if (state->rx_miss_count < 255U)
+    {
+        state->rx_miss_count++;
+    }
+
+    /*
+     * Radar period = 20 ms, our tick = 10 ms.
+     * 3 missed frames ≈ 6 ticks of 10 ms = 60 ms.
+     * We use CAN_RX_TIMEOUT_CYCLES (3) as a count of our 20-ms-equivalent
+     * intervals, so threshold = 3 * 2 = 6 ticks.
+     */
+    if (state->rx_miss_count >= (CAN_RX_TIMEOUT_CYCLES * 2U))
+    {
+        state->last_rx.rx_timeout_flag = 1U;
+    }
+    } /* end null guard */
 }
 
-int32_t can_tx_brake_cmd(can_state_t *state,
+/**
+ * @brief Transmit AEB_BrakeCmd (0x080) with alive counter and CRC.
+ * @req FR-CAN-003
+ */
+int32_t can_tx_brake_cmd(can_state_t       *state,
                          const pid_output_t *pid_out,
                          const fsm_output_t *fsm_out)
 {
-    (void)state;
-    (void)pid_out;
-    (void)fsm_out;
-    return CAN_OK;
+    int32_t result = CAN_OK;
+
+    if ((state == NULL) || (pid_out == NULL) || (fsm_out == NULL))
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        uint8_t frame[8]   = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U};
+        uint8_t brake_mode = 0U;
+
+        /* BrakeRequest: bit 0, 1 bit */
+        uint32_t brake_req = (pid_out->brake_pct > 0.0F) ? 1U : 0U;
+        can_pack_signal(frame, 0U, 1U, brake_req);
+
+        /* BrakePressure: bits 1..15, factor 0.1, offset 0 */
+        uint32_t raw_press = encode_unsigned(pid_out->brake_bar, 0.1F, 0.0F);
+        can_pack_signal(frame, 1U, 15U, raw_press);
+
+        /* BrakeMode: bits 16..18, 3 bits — map FSM state to brake mode */
+        switch (fsm_out->fsm_state)
+        {
+            case (uint8_t)FSM_OFF:        brake_mode = 0U; break;
+            case (uint8_t)FSM_STANDBY:    brake_mode = 0U; break;
+            case (uint8_t)FSM_WARNING:    brake_mode = 1U; break;
+            case (uint8_t)FSM_BRAKE_L1:   brake_mode = 2U; break;
+            case (uint8_t)FSM_BRAKE_L2:   brake_mode = 3U; break;
+            case (uint8_t)FSM_BRAKE_L3:   brake_mode = 4U; break;
+            case (uint8_t)FSM_POST_BRAKE: brake_mode = 5U; break;
+            default:                      brake_mode = 0U; break;
+        }
+        can_pack_signal(frame, 16U, 3U, (uint32_t)brake_mode);
+
+        /* AliveCounter: bits 24..27, 4 bits */
+        can_pack_signal(frame, 24U, 4U, (uint32_t)state->alive_counter);
+
+        /* CRC: bits 28..31, 4 bits — computed over bytes 0..2 */
+        uint8_t crc = compute_crc4(frame, 3U);
+        can_pack_signal(frame, 28U, 4U, (uint32_t)crc);
+
+        /* Increment alive counter (wraps at 15) */
+        state->alive_counter++;
+        if (state->alive_counter > ALIVE_COUNTER_MAX)
+        {
+            state->alive_counter = 0U;
+        }
+
+        /* Send via HAL */
+        if (can_hal_send(CAN_ID_BRAKE_CMD, frame, CAN_DLC_BRAKE_CMD) != 0)
+        {
+            result = CAN_ERR_TX;
+        }
+    }
+
+    return result;
 }
 
-int32_t can_tx_fsm_state(can_state_t *state,
+/**
+ * @brief Transmit AEB_FSMState (0x200) every 50 ms.
+ * @req FR-CAN-001
+ */
+int32_t can_tx_fsm_state(can_state_t       *state,
                          const fsm_output_t *fsm_out)
 {
-    (void)state;
-    (void)fsm_out;
-    return 1;
+    int32_t result = 1;   /* 1 = not yet due */
+
+    if ((state == NULL) || (fsm_out == NULL))
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        state->tx_cycle_counter++;
+
+        /* 50 ms / 10 ms = every 5 ticks */
+        if (state->tx_cycle_counter >= 5U)
+        {
+            uint8_t frame[4] = {0U, 0U, 0U, 0U};
+
+            state->tx_cycle_counter = 0U;
+
+            /* FSMState: bits 0..7 */
+            can_pack_signal(frame, 0U, 8U, (uint32_t)fsm_out->fsm_state);
+
+            /* AlertLevel: bits 8..15 */
+            can_pack_signal(frame, 8U, 8U, (uint32_t)fsm_out->alert_level);
+
+            /* BrakeActive: bits 16..23 */
+            can_pack_signal(frame, 16U, 8U, (uint32_t)fsm_out->brake_active);
+
+            /* TTCThreshold: bits 24..31, factor 0.1, offset 0 */
+            float32_t ttc_thresh = 0.0F;
+            switch (fsm_out->fsm_state)
+            {
+                case (uint8_t)FSM_WARNING:    ttc_thresh = TTC_WARNING;  break;
+                case (uint8_t)FSM_BRAKE_L1:   ttc_thresh = TTC_BRAKE_L1; break;
+                case (uint8_t)FSM_BRAKE_L2:   ttc_thresh = TTC_BRAKE_L2; break;
+                case (uint8_t)FSM_BRAKE_L3:   ttc_thresh = TTC_BRAKE_L3; break;
+                default:                      ttc_thresh = 0.0F;         break;
+            }
+            uint32_t raw_ttc = encode_unsigned(ttc_thresh, 0.1F, 0.0F);
+            can_pack_signal(frame, 24U, 8U, raw_ttc);
+
+            if (can_hal_send(CAN_ID_FSM_STATE, frame, CAN_DLC_FSM_STATE) != 0)
+            {
+                result = CAN_ERR_TX;
+            }
+            else
+            {
+                result = CAN_OK;
+            }
+        }
+    }
+
+    return result;
 }
 
+/**
+ * @brief Transmit AEB_Alert (0x300).
+ * @req FR-CAN-003
+ */
 int32_t can_tx_alert(const alert_output_t *alert_out)
 {
-    (void)alert_out;
-    return CAN_OK;
+    int32_t result = CAN_OK;
+
+    if (alert_out == NULL)
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        uint8_t frame[2] = {0U, 0U};
+        /* AlertType: bits 0..7, 8 bits, factor 1, offset 0 */
+        can_pack_signal(frame, 0U, 8U, (uint32_t)alert_out->alert_type);
+
+        /* AlertActive: bit 8, 1 bit */
+        can_pack_signal(frame, 8U, 1U, (uint32_t)alert_out->alert_active);
+
+        /* BuzzerCmd: bits 9..11, 3 bits */
+        can_pack_signal(frame, 9U, 3U, (uint32_t)alert_out->buzzer_cmd);
+
+        if (can_hal_send(CAN_ID_ALERT, frame, CAN_DLC_ALERT) != 0)
+        {
+            result = CAN_ERR_TX;
+        }
+    }
+
+    return result;
 }
 
+/**
+ * @brief Copy latest RX data to caller's struct.
+ */
 void can_get_rx_data(const can_state_t *state,
-                     can_rx_data_t *out)
+                     can_rx_data_t     *out)
 {
-    if ((state != (void *)0) && (out != (void *)0))
+    if ((state != NULL) && (out != NULL))
     {
         (void)memcpy(out, &state->last_rx, sizeof(can_rx_data_t));
     }

--- a/src/communication/aeb_uds.c
+++ b/src/communication/aeb_uds.c
@@ -1,0 +1,26 @@
+/**
+ * @file  aeb_uds.c
+ * @brief UDS Diagnostics — STUB (Task E placeholder).
+ *
+ * This file will be replaced by Rian's implementation.
+ */
+
+#include "aeb_types.h"
+#include <stdint.h>
+
+void uds_init(void)
+{
+    /* STUB — Task E (Rian) */
+}
+
+void uds_process_request(const uint8_t sid,
+                         const uint8_t did_high,
+                         const uint8_t did_low,
+                         const uint8_t value)
+{
+    (void)sid;
+    (void)did_high;
+    (void)did_low;
+    (void)value;
+    /* STUB — Task E (Rian) */
+}

--- a/src/decision/aeb_fsm.c
+++ b/src/decision/aeb_fsm.c
@@ -1,0 +1,31 @@
+/**
+ * @file  aeb_fsm.c
+ * @brief Finite State Machine — STUB (Task B placeholder).
+ *
+ * This file will be replaced by Lourenco's implementation.
+ */
+
+#include "aeb_types.h"
+
+void fsm_init(fsm_output_t *out)
+{
+    if (out != (void *)0)
+    {
+        out->fsm_state    = (uint8_t)FSM_OFF;
+        out->decel_target = 0.0F;
+        out->brake_active = 0U;
+        out->alert_level  = 0U;
+        out->warn_timer   = 0.0F;
+        out->state_timer  = 0.0F;
+    }
+}
+
+void fsm_step(const perception_output_t *perc,
+              const driver_input_t *driver,
+              fsm_output_t *out)
+{
+    (void)perc;
+    (void)driver;
+    (void)out;
+    /* STUB — Task B (Lourenco) */
+}

--- a/src/decision/aeb_fsm.c
+++ b/src/decision/aeb_fsm.c
@@ -1,31 +1,333 @@
 /**
- * @file  aeb_fsm.c
- * @brief Finite State Machine — STUB (Task B placeholder).
- *
- * This file will be replaced by Lourenco's implementation.
+ * @file aeb_fsm.c
+ * @brief Implementation of 7-state AEB Finite State Machine.
+ * @author Lourenço Jamba Mphili
+ * @requirements FR-FSM-001 to FR-FSM-006, FR-DEC-004 to FR-DEC-011
+ * @misra Fully compliant with MISRA C:2012
  */
 
+#include "aeb_fsm.h"
+#include "aeb_config.h"
 #include "aeb_types.h"
+#include <stddef.h>
 
-void fsm_init(fsm_output_t *out)
+/* Steering override threshold (degrees) - FR-FSM-006 */
+#ifndef STEERING_OVERRIDE_DEG
+#define STEERING_OVERRIDE_DEG   5.0f
+#endif
+
+/* FSM internal persistent memory (private to this module) */
+static struct {
+    float32_t warn_timer_s;       /**< Time spent in WARNING state */
+    float32_t debounce_timer_s;   /**< Debounce timer for de-escalation */
+    float32_t post_brake_timer_s; /**< Hold timer for POST_BRAKE state */
+} m_fsm_mem = {0.0f, 0.0f, 0.0f};
+
+/**
+ * @brief Converts FSM state to deceleration target.
+ * @requirement FR-BRK-001, SRS Table 10
+ */
+static float32_t state_to_decel_target(fsm_state_e state)
 {
-    if (out != (void *)0)
+    float32_t decel = 0.0f;
+
+    switch (state) {
+        case FSM_BRAKE_L1:
+            decel = DECEL_L1;  /* 2.0f m/s² */
+            break;
+        case FSM_BRAKE_L2:
+            decel = DECEL_L2;  /* 4.0f m/s² */
+            break;
+        case FSM_BRAKE_L3:
+            decel = DECEL_L3;  /* 6.0f m/s² */
+            break;
+        default:
+            decel = 0.0f;
+            break;
+    }
+
+    return decel;
+}
+
+/**
+ * @brief Converts FSM state to alert level (0..2)
+ */
+static uint8_t state_to_alert_level(fsm_state_e state)
+{
+    uint8_t alert = 0U;
+
+    if ((state == FSM_WARNING) || (state == FSM_BRAKE_L1))
     {
-        out->fsm_state    = (uint8_t)FSM_OFF;
-        out->decel_target = 0.0F;
-        out->brake_active = 0U;
-        out->alert_level  = 0U;
-        out->warn_timer   = 0.0F;
-        out->state_timer  = 0.0F;
+        alert = 1U;  /* Warning alert */
+    }
+    else if ((state == FSM_BRAKE_L2) || (state == FSM_BRAKE_L3))
+    {
+        alert = 2U;  /* Emergency alert */
+    }
+    else
+    {
+        alert = 0U;  /* No alert */
+    }
+
+    return alert;
+}
+
+/**
+ * @brief Evaluates desired state based on TTC, distance, and braking distance.
+ * @return Desired FSM state
+ * @requirement FR-DEC-004, FR-DEC-005
+ */
+static fsm_state_e evaluate_desired_state(const perception_output_t * const perception,
+                                           const ttc_output_t * const ttc_in)
+{
+    fsm_state_e desired = FSM_STANDBY;
+
+    /* FR-DEC-004: No threat if not closing */
+    if (ttc_in->is_closing == 0U)
+    {
+        desired = FSM_STANDBY;
+    }
+    /* FR-DEC-005: Braking floor condition (highest priority) */
+    else if (ttc_in->d_brake >= perception->distance)
+    {
+        desired = FSM_BRAKE_L3;
+    }
+    /* Distance floors - per SRS Table 10 */
+    else if (perception->distance <= 5.0f)
+    {
+        desired = FSM_BRAKE_L3;
+    }
+    else if (perception->distance <= 10.0f)
+    {
+        desired = FSM_BRAKE_L2;
+    }
+    else if (perception->distance <= 20.0f)
+    {
+        desired = FSM_BRAKE_L1;
+    }
+    /* TTC-based evaluation - per SRS Table 10 */
+    else if (ttc_in->ttc <= TTC_BRAKE_L3)
+    {
+        desired = FSM_BRAKE_L3;
+    }
+    else if (ttc_in->ttc <= TTC_BRAKE_L2)
+    {
+        desired = FSM_BRAKE_L2;
+    }
+    else if (ttc_in->ttc <= TTC_BRAKE_L1)
+    {
+        desired = FSM_BRAKE_L1;
+    }
+    else if (ttc_in->ttc <= TTC_WARNING)
+    {
+        desired = FSM_WARNING;
+    }
+    else
+    {
+        desired = FSM_STANDBY;
+    }
+
+    return desired;
+}
+
+void fsm_init(fsm_output_t * const fsm_out)
+{
+    if (fsm_out != NULL)
+    {
+        /* FR-FSM-001: Initial state is STANDBY */
+        fsm_out->fsm_state = (uint8_t)FSM_STANDBY;
+        fsm_out->decel_target = 0.0f;
+        fsm_out->brake_active = 0U;
+        fsm_out->alert_level = 0U;
+        fsm_out->warn_timer = 0.0f;
+        fsm_out->state_timer = 0.0f;
+
+        /* Reset internal memory */
+        m_fsm_mem.warn_timer_s = 0.0f;
+        m_fsm_mem.debounce_timer_s = 0.0f;
+        m_fsm_mem.post_brake_timer_s = 0.0f;
     }
 }
 
-void fsm_step(const perception_output_t *perc,
-              const driver_input_t *driver,
-              fsm_output_t *out)
+void fsm_step(float32_t delta_t_s,
+              const perception_output_t * const perception,
+              const driver_input_t * const driver,
+              const ttc_output_t * const ttc_in,
+              fsm_output_t * const fsm_out)
 {
-    (void)perc;
-    (void)driver;
-    (void)out;
-    /* STUB — Task B (Lourenco) */
+    fsm_state_e current_state;
+    fsm_state_e desired_state;
+    fsm_state_e new_state;
+    uint8_t driver_override = 0U;
+    uint8_t speed_out_of_range = 0U;
+
+    /* Defensive checks */
+    if ((delta_t_s <= 0.0f) || (perception == NULL) ||
+        (driver == NULL) || (ttc_in == NULL) || (fsm_out == NULL))
+    {
+        return;
+    }
+
+    current_state = (fsm_state_e)fsm_out->fsm_state;
+    desired_state = evaluate_desired_state(perception, ttc_in);
+
+    /* ===== PRIORITY 1: Fault and Safety ===== */
+    if ((perception->fault_flag != 0U) || (driver->aeb_enabled == 0U))
+    {
+        fsm_out->fsm_state = (uint8_t)FSM_OFF;
+        fsm_out->brake_active = 0U;
+        fsm_out->alert_level = 0U;
+        fsm_out->decel_target = 0.0f;
+        fsm_out->warn_timer = 0.0f;
+        fsm_out->state_timer = 0.0f;
+        m_fsm_mem.warn_timer_s = 0.0f;
+        m_fsm_mem.debounce_timer_s = 0.0f;
+        m_fsm_mem.post_brake_timer_s = 0.0f;
+        return;
+    }
+
+    /* ===== PRIORITY 2: Driver Override ===== */
+    driver_override = (driver->brake_pedal != 0U) ||
+                      (driver->steering_angle > STEERING_OVERRIDE_DEG) ||
+                      (driver->steering_angle < -STEERING_OVERRIDE_DEG);
+
+    if ((driver_override != 0U) && (current_state != FSM_POST_BRAKE))
+    {
+        fsm_out->fsm_state = (uint8_t)FSM_STANDBY;
+        fsm_out->brake_active = 0U;
+        fsm_out->alert_level = 0U;
+        fsm_out->decel_target = 0.0f;
+        fsm_out->warn_timer = 0.0f;
+        fsm_out->state_timer = 0.0f;
+        m_fsm_mem.warn_timer_s = 0.0f;
+        m_fsm_mem.debounce_timer_s = 0.0f;
+        return;
+    }
+
+    /* ===== PRIORITY 3: Speed Range Validation ===== */
+    speed_out_of_range = (perception->v_ego < V_EGO_MIN) ||
+                         (perception->v_ego > V_EGO_MAX);
+
+    if (speed_out_of_range != 0U)
+    {
+        if ((perception->v_ego < 0.01f) && (current_state >= FSM_BRAKE_L1))
+        {
+            fsm_out->fsm_state = (uint8_t)FSM_POST_BRAKE;
+            m_fsm_mem.post_brake_timer_s = 0.0f;
+        }
+        else
+        {
+            fsm_out->fsm_state = (uint8_t)FSM_STANDBY;
+        }
+        fsm_out->brake_active = 0U;
+        fsm_out->alert_level = 0U;
+        fsm_out->decel_target = 0.0f;
+        fsm_out->state_timer += delta_t_s;
+        return;
+    }
+
+    /* ===== PRIORITY 4: State Transition Logic ===== */
+    new_state = current_state;
+
+    switch (current_state)
+    {
+        case FSM_POST_BRAKE:
+            m_fsm_mem.post_brake_timer_s += delta_t_s;
+            if ((m_fsm_mem.post_brake_timer_s >= 2.0f) ||
+                (driver->accel_pedal != 0U))
+            {
+                new_state = FSM_STANDBY;
+                m_fsm_mem.post_brake_timer_s = 0.0f;
+            }
+            break;
+
+        case FSM_WARNING:
+            m_fsm_mem.warn_timer_s += delta_t_s;
+            if (desired_state == FSM_STANDBY)
+            {
+                m_fsm_mem.debounce_timer_s += delta_t_s;
+                if (m_fsm_mem.debounce_timer_s >= 0.2f)
+                {
+                    new_state = desired_state;
+                    m_fsm_mem.warn_timer_s = 0.0f;
+                    m_fsm_mem.debounce_timer_s = 0.0f;
+                }
+            }
+            else if ((desired_state == FSM_BRAKE_L1) ||
+                     (desired_state == FSM_BRAKE_L2) ||
+                     (desired_state == FSM_BRAKE_L3))
+            {
+                if (m_fsm_mem.warn_timer_s >= 0.8f)
+                {
+                    new_state = desired_state;
+                    m_fsm_mem.debounce_timer_s = 0.0f;
+                }
+            }
+            break;
+
+        case FSM_BRAKE_L1:
+        case FSM_BRAKE_L2:
+        case FSM_BRAKE_L3:
+            if (perception->v_ego < 0.01f)
+            {
+                new_state = FSM_POST_BRAKE;
+                m_fsm_mem.post_brake_timer_s = 0.0f;
+            }
+            else if (desired_state > current_state)
+            {
+                /* Escalation: immediate */
+                new_state = desired_state;
+                m_fsm_mem.debounce_timer_s = 0.0f;
+            }
+            else if (desired_state < current_state)
+            {
+                /* De-escalation: requires 200ms debounce */
+                m_fsm_mem.debounce_timer_s += delta_t_s;
+                if (m_fsm_mem.debounce_timer_s >= 0.2f)
+                {
+                    new_state = desired_state;
+                    m_fsm_mem.debounce_timer_s = 0.0f;
+                }
+            }
+            else
+            {
+                m_fsm_mem.debounce_timer_s = 0.0f;
+            }
+            break;
+
+        case FSM_STANDBY:
+        default:
+            m_fsm_mem.warn_timer_s = 0.0f;
+            m_fsm_mem.debounce_timer_s = 0.0f;
+            /* FR-DEC-011: STANDBY must go to WARNING first */
+            if (desired_state == FSM_WARNING)
+            {
+                new_state = FSM_WARNING;
+            }
+            else if ((desired_state == FSM_BRAKE_L1) ||
+                     (desired_state == FSM_BRAKE_L2) ||
+                     (desired_state == FSM_BRAKE_L3))
+            {
+                /* Force pass through WARNING (FR-DEC-011) */
+                new_state = FSM_WARNING;
+            }
+            break;
+    }
+
+    /* Update timers */
+    if (new_state != current_state)
+    {
+        fsm_out->state_timer = 0.0f;
+    }
+    else
+    {
+        fsm_out->state_timer += delta_t_s;
+    }
+
+    /* Write outputs */
+    fsm_out->fsm_state = (uint8_t)new_state;
+    fsm_out->warn_timer = m_fsm_mem.warn_timer_s;
+    fsm_out->brake_active = ((new_state >= FSM_BRAKE_L1) && (new_state <= FSM_BRAKE_L3)) ? 1U : 0U;
+    fsm_out->alert_level = state_to_alert_level(new_state);
+    fsm_out->decel_target = state_to_decel_target(new_state);
 }

--- a/src/decision/aeb_ttc.c
+++ b/src/decision/aeb_ttc.c
@@ -1,25 +1,72 @@
 /**
- * @file  aeb_ttc.c
- * @brief TTC Calculation — STUB (Task B placeholder).
- *
- * This file will be replaced by Lourenco's implementation.
+ * @file aeb_ttc.c
+ * @brief Implementation of TTC and braking distance calculations.
+ * @author Lourenço Jamba Mphili
+ * @requirements FR-DEC-001, FR-DEC-002, FR-DEC-003
+ * @misra Fully compliant with MISRA C:2012
  */
 
-#include "aeb_types.h"
+#include "aeb_ttc.h"
+#include "aeb_config.h"
+#include <stddef.h>
 
-void ttc_calc(const float32_t distance,
-              const float32_t v_ego,
-              const float32_t v_target,
-              ttc_output_t *out)
+float32_t ttc_calc(float32_t distance, float32_t v_rel)
 {
-    (void)distance;
-    (void)v_ego;
-    (void)v_target;
+    float32_t ttc_result = TTC_MAX;
 
-    if (out != (void *)0)
+    /* Safety check for invalid distance */
+    if (distance > 0.0f)
     {
-        out->ttc        = 10.0F;
-        out->d_brake    = 0.0F;
-        out->is_closing = 0U;
+        /* FR-DEC-001: Only calculate when approaching (v_rel > V_REL_MIN) */
+        if (v_rel > V_REL_MIN)
+        {
+            ttc_result = distance / v_rel;
+
+            /* Clamp to [0, TTC_MAX] seconds per SRS */
+            if (ttc_result > TTC_MAX)
+            {
+                ttc_result = TTC_MAX;
+            }
+            else if (ttc_result < 0.0f)
+            {
+                ttc_result = 0.0f;
+            }
+        }
     }
+
+    return ttc_result;
+}
+
+float32_t d_brake_calc(float32_t v_ego)
+{
+    float32_t d_brake;
+
+    /* FR-DEC-002: d_brake = v² / (2 * a) with a = DECEL_L3 = 6.0 m/s² */
+    d_brake = (v_ego * v_ego) / (2.0f * DECEL_L3);
+
+    /* Physical lower bound */
+    if (d_brake < 0.0f)
+    {
+        d_brake = 0.0f;
+    }
+
+    return d_brake;
+}
+
+void ttc_process(const perception_output_t * const perception,
+                 ttc_output_t * const ttc_out)
+{
+    /* Defensive checks */
+    if ((perception == NULL) || (ttc_out == NULL))
+    {
+        return;
+    }
+
+    /* FR-DEC-003: Use v_rel directly from perception (Task A already computed it) */
+    /* Set closing flag (v_rel > V_REL_MIN means approaching) */
+    ttc_out->is_closing = (perception->v_rel > V_REL_MIN) ? 1U : 0U;
+
+    /* Calculate TTC and braking distance */
+    ttc_out->ttc = ttc_calc(perception->distance, perception->v_rel);
+    ttc_out->d_brake = d_brake_calc(perception->v_ego);
 }

--- a/src/decision/aeb_ttc.c
+++ b/src/decision/aeb_ttc.c
@@ -1,0 +1,25 @@
+/**
+ * @file  aeb_ttc.c
+ * @brief TTC Calculation — STUB (Task B placeholder).
+ *
+ * This file will be replaced by Lourenco's implementation.
+ */
+
+#include "aeb_types.h"
+
+void ttc_calc(const float32_t distance,
+              const float32_t v_ego,
+              const float32_t v_target,
+              ttc_output_t *out)
+{
+    (void)distance;
+    (void)v_ego;
+    (void)v_target;
+
+    if (out != (void *)0)
+    {
+        out->ttc        = 10.0F;
+        out->d_brake    = 0.0F;
+        out->is_closing = 0U;
+    }
+}

--- a/src/execution/aeb_alert.c
+++ b/src/execution/aeb_alert.c
@@ -1,0 +1,20 @@
+/**
+ * @file  aeb_alert.c
+ * @brief Alert Mapping — STUB (Task C placeholder).
+ *
+ * This file will be replaced by Jessica's implementation.
+ */
+
+#include "aeb_types.h"
+
+void alert_map(const uint8_t fsm_state, alert_output_t *out)
+{
+    (void)fsm_state;
+
+    if (out != (void *)0)
+    {
+        out->alert_type   = 0U;
+        out->alert_active = 0U;
+        out->buzzer_cmd   = 0U;
+    }
+}

--- a/src/execution/aeb_pid.c
+++ b/src/execution/aeb_pid.c
@@ -1,0 +1,29 @@
+/**
+ * @file  aeb_pid.c
+ * @brief PID Brake Controller — STUB (Task C placeholder).
+ *
+ * This file will be replaced by Jessica's implementation.
+ */
+
+#include "aeb_types.h"
+
+void pid_init(void)
+{
+    /* STUB — Task C (Jessica) */
+}
+
+void pid_brake_step(const float32_t decel_target,
+                    const float32_t a_ego,
+                    const uint8_t   fsm_state,
+                    pid_output_t *out)
+{
+    (void)decel_target;
+    (void)a_ego;
+    (void)fsm_state;
+
+    if (out != (void *)0)
+    {
+        out->brake_pct = 0.0F;
+        out->brake_bar = 0.0F;
+    }
+}

--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -1,0 +1,35 @@
+/**
+ * @file  aeb_perception.c
+ * @brief Perception and Sensor Fusion — STUB (Task A placeholder).
+ *
+ * This file will be replaced by Eryca's implementation.
+ * Provides empty function bodies so the project compiles and CI passes.
+ */
+
+#include "aeb_types.h"
+
+void perception_init(void)
+{
+    /* STUB — Task A (Eryca) */
+}
+
+void perception_step(const float32_t d_radar,
+                     const float32_t vr_radar,
+                     const float32_t d_lidar,
+                     const float32_t ve_ego,
+                     perception_output_t *out)
+{
+    (void)d_radar;
+    (void)vr_radar;
+    (void)d_lidar;
+    (void)ve_ego;
+
+    if (out != (void *)0)
+    {
+        out->distance   = 0.0F;
+        out->v_ego      = 0.0F;
+        out->v_rel      = 0.0F;
+        out->confidence = 0.0F;
+        out->fault_flag = 0U;
+    }
+}

--- a/stubs/can_hal.c
+++ b/stubs/can_hal.c
@@ -1,0 +1,133 @@
+/**
+ * @file  can_hal.c
+ * @brief CAN HAL stub implementation for host-based testing.
+ *
+ * Records TX frames in a circular buffer so unit tests can inspect them.
+ * On Zephyr, this file is NOT compiled — the real CAN driver is used.
+ */
+
+#include "can_hal.h"
+#include <string.h>
+
+/* ── TX capture buffer for test inspection ──────────────────────────── */
+#define TX_BUF_SIZE  (32U)
+
+typedef struct
+{
+    uint32_t id;
+    uint8_t  data[8];
+    uint8_t  dlc;
+} tx_record_t;
+
+static tx_record_t tx_buffer[TX_BUF_SIZE];
+static uint32_t    tx_count = 0U;
+
+/* ── RX filter registry ─────────────────────────────────────────────── */
+#define MAX_FILTERS  (8U)
+
+static uint32_t rx_filters[MAX_FILTERS];
+static uint32_t rx_filter_count = 0U;
+
+/* ── Fault injection ────────────────────────────────────────────────── */
+static int32_t  force_init_fail = 0;
+static int32_t  force_send_fail = 0;
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  HAL API (stub)
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+int32_t can_hal_init(uint32_t baud_rate)
+{
+    (void)baud_rate;
+
+    if (force_init_fail != 0)
+    {
+        return -1;
+    }
+
+    tx_count = 0U;
+    rx_filter_count = 0U;
+    return 0;
+}
+
+int32_t can_hal_add_rx_filter(uint32_t msg_id)
+{
+    int32_t result = -1;
+
+    if (rx_filter_count < MAX_FILTERS)
+    {
+        rx_filters[rx_filter_count] = msg_id;
+        result = (int32_t)rx_filter_count;
+        rx_filter_count++;
+    }
+
+    return result;
+}
+
+int32_t can_hal_send(uint32_t id, const uint8_t *data, uint8_t dlc)
+{
+    int32_t result = -1;
+
+    if (force_send_fail != 0)
+    {
+        result = -1;
+    }
+    else if ((data != NULL) && (dlc <= 8U) && (tx_count < TX_BUF_SIZE))
+    {
+        tx_buffer[tx_count].id  = id;
+        tx_buffer[tx_count].dlc = dlc;
+        (void)memcpy(tx_buffer[tx_count].data, data, (size_t)dlc);
+        tx_count++;
+        result = 0;
+    }
+    else
+    {
+        /* buffer full or invalid args */
+    }
+
+    return result;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST HELPERS (called from test_can.c)
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/** @brief Get count of transmitted frames since last init/reset. */
+uint32_t can_hal_test_get_tx_count(void)
+{
+    return tx_count;
+}
+
+/** @brief Get pointer to the Nth transmitted frame. */
+const tx_record_t *can_hal_test_get_tx(uint32_t index)
+{
+    const tx_record_t *rec = NULL;
+
+    if (index < tx_count)
+    {
+        rec = &tx_buffer[index];
+    }
+
+    return rec;
+}
+
+/** @brief Reset TX buffer. */
+void can_hal_test_reset(void)
+{
+    tx_count = 0U;
+    rx_filter_count = 0U;
+    force_init_fail = 0;
+    force_send_fail = 0;
+}
+
+/** @brief Force can_hal_init() to fail (for negative testing). */
+void can_hal_test_force_init_fail(int32_t fail)
+{
+    force_init_fail = fail;
+}
+
+/** @brief Force can_hal_send() to fail (for negative testing). */
+void can_hal_test_force_send_fail(int32_t fail)
+{
+    force_send_fail = fail;
+}

--- a/stubs/can_hal.h
+++ b/stubs/can_hal.h
@@ -1,0 +1,41 @@
+/**
+ * @file  can_hal.h
+ * @brief CAN Hardware Abstraction Layer — stub for host compilation.
+ *
+ * On Zephyr, this file is replaced by the real Zephyr CAN driver calls.
+ * This stub allows compiling and testing aeb_can.c on a host PC
+ * (gcc / cppcheck / MISRA checker) without the Zephyr SDK.
+ */
+
+#ifndef CAN_HAL_H
+#define CAN_HAL_H
+
+#include <stdint.h>
+
+/** @brief CAN baud rate selector. */
+#define CAN_BAUD_500K   500000U
+
+/**
+ * @brief Initialise CAN peripheral.
+ * @param baud_rate  Baud rate in bit/s (e.g. 500000).
+ * @return 0 on success, -1 on failure.
+ */
+int32_t can_hal_init(uint32_t baud_rate);
+
+/**
+ * @brief Register an RX acceptance filter for a CAN message ID.
+ * @param msg_id  Standard 11-bit CAN ID to accept.
+ * @return Filter handle (>=0) on success, -1 on failure.
+ */
+int32_t can_hal_add_rx_filter(uint32_t msg_id);
+
+/**
+ * @brief Send a CAN frame (non-blocking).
+ * @param id    Standard 11-bit CAN ID.
+ * @param data  Pointer to payload (up to 8 bytes).
+ * @param dlc   Data Length Code (0..8).
+ * @return 0 on success, -1 on failure.
+ */
+int32_t can_hal_send(uint32_t id, const uint8_t *data, uint8_t dlc);
+
+#endif /* CAN_HAL_H */

--- a/tests/test_can.c
+++ b/tests/test_can.c
@@ -1,0 +1,363 @@
+/**
+ * @file  test_can.c
+ * @brief Unit tests for aeb_can module.
+ *
+ * Uses a minimal assert framework for host compilation.
+ * Can be adapted to Zephyr ztest by replacing ASSERT macros.
+ */
+
+#include "aeb_can.h"
+#include "can_hal.h"
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+/* ── Minimal test framework ─────────────────────────────────────────── */
+static int32_t tests_run    = 0;
+static int32_t tests_passed = 0;
+static int32_t tests_failed = 0;
+
+#define ASSERT_EQ(a, b) do { \
+    if ((a) == (b)) { tests_passed++; } \
+    else { printf("  FAIL: %s:%d  %s != %s\n", __FILE__, __LINE__, #a, #b); tests_failed++; } \
+    tests_run++; \
+} while (0)
+
+#define ASSERT_FLOAT_NEAR(a, b, tol) do { \
+    if (fabsf((float)(a) - (float)(b)) <= (float)(tol)) { tests_passed++; } \
+    else { printf("  FAIL: %s:%d  %s=%.4f != %s=%.4f (tol=%.4f)\n", \
+           __FILE__, __LINE__, #a, (double)(a), #b, (double)(b), (double)(tol)); tests_failed++; } \
+    tests_run++; \
+} while (0)
+
+#define TEST(name) static void name(void)
+#define RUN(name) do { printf("  [TEST] %s\n", #name); name(); } while (0)
+
+/* ── Extern test helpers from can_hal.c stub ────────────────────────── */
+extern uint32_t       can_hal_test_get_tx_count(void);
+extern void           can_hal_test_reset(void);
+extern void           can_hal_test_force_init_fail(int32_t fail);
+extern void           can_hal_test_force_send_fail(int32_t fail);
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: Signal pack/unpack round-trip  (FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_signal_roundtrip)
+{
+    uint8_t buf[8] = {0};
+
+    /* Pack 0xABCD into bits 4..19 (16 bits) */
+    can_pack_signal(buf, 4U, 16U, 0xABCDU);
+    uint32_t val = can_unpack_signal(buf, 4U, 16U);
+    ASSERT_EQ(val, 0xABCDU);
+
+    /* Pack single bit */
+    (void)memset(buf, 0, sizeof(buf));
+    can_pack_signal(buf, 0U, 1U, 1U);
+    ASSERT_EQ(can_unpack_signal(buf, 0U, 1U), 1U);
+    ASSERT_EQ(buf[0] & 0x01U, 0x01U);
+
+    /* Pack 4-bit value at bit 24 */
+    (void)memset(buf, 0, sizeof(buf));
+    can_pack_signal(buf, 24U, 4U, 0x0FU);
+    ASSERT_EQ(can_unpack_signal(buf, 24U, 4U), 0x0FU);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: can_init success and failure  (FR-CAN-004)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_init_success)
+{
+    can_state_t state;
+    can_hal_test_reset();
+
+    int32_t rc = can_init(&state);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(state.initialised, 1U);
+    ASSERT_EQ(state.alive_counter, 0U);
+}
+
+TEST(test_init_failure)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    can_hal_test_force_init_fail(1);
+
+    int32_t rc = can_init(&state);
+    ASSERT_EQ(rc, CAN_ERR_INIT);
+    ASSERT_EQ(state.initialised, 0U);
+
+    can_hal_test_force_init_fail(0);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — EgoVehicle (0x100)  (FR-CAN-002, FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_ego_vehicle)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* Construct a frame: VehicleSpeed=13.89 m/s (50 km/h)
+     * raw = 13.89 / 0.01 = 1389 = 0x056D */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 0U, 16U, 1389U);   /* VehicleSpeed */
+
+    /* LongAccel = -2.0 m/s^2 → raw = (-2.0 - (-32)) / 0.001 = 30000 */
+    can_pack_signal(frame, 16U, 16U, 30000U);
+
+    /* SteeringAngle = 10.0 deg → raw = (10.0 - (-3276.8)) / 0.1 = 32868 */
+    can_pack_signal(frame, 48U, 16U, 32868U);
+
+    can_rx_process(&state, CAN_ID_EGO_VEHICLE, frame, 8U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_FLOAT_NEAR(rx.vehicle_speed, 13.89F, 0.02F);
+    ASSERT_FLOAT_NEAR(rx.long_accel, -2.0F, 0.01F);
+    ASSERT_FLOAT_NEAR(rx.steering_angle, 10.0F, 0.2F);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — RadarTarget (0x120)  (FR-CAN-002, FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_radar_target)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* TargetDistance = 50.0 m → raw = 50.0 / 0.01 = 5000 */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 0U, 16U, 5000U);
+
+    /* RelativeSpeed = -5.0 m/s → raw = (-5.0 - (-327.68)) / 0.01 = 32268 */
+    can_pack_signal(frame, 16U, 16U, 32268U);
+
+    /* TTC = 3.5 s → raw = 3.5 / 0.001 = 3500 */
+    can_pack_signal(frame, 32U, 16U, 3500U);
+
+    /* Confidence = 12 */
+    can_pack_signal(frame, 48U, 8U, 12U);
+
+    can_rx_process(&state, CAN_ID_RADAR_TARGET, frame, 8U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_FLOAT_NEAR(rx.target_distance, 50.0F, 0.02F);
+    ASSERT_FLOAT_NEAR(rx.relative_speed, -5.0F, 0.02F);
+    ASSERT_FLOAT_NEAR(rx.ttc_radar, 3.5F, 0.002F);
+    ASSERT_EQ(rx.confidence_raw, 12U);
+    ASSERT_EQ(rx.rx_timeout_flag, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — DriverInput (0x101)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_driver_input)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* BrakePedal=80%, AccelPedal=0%, AEB_Enable=1, DriverOverride=0 */
+    uint8_t frame[4] = {0};
+    can_pack_signal(frame, 0U, 8U, 80U);   /* BrakePedal */
+    can_pack_signal(frame, 8U, 8U, 0U);    /* AccelPedal */
+    can_pack_signal(frame, 16U, 1U, 1U);   /* AEB_Enable */
+    can_pack_signal(frame, 17U, 1U, 0U);   /* DriverOverride */
+
+    can_rx_process(&state, CAN_ID_DRIVER_INPUT, frame, 4U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_EQ(rx.brake_pedal, 80U);
+    ASSERT_EQ(rx.accel_pedal, 0U);
+    ASSERT_EQ(rx.aeb_enable, 1U);
+    ASSERT_EQ(rx.driver_override, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — YawRate from EgoVehicle
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_yaw_rate)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* YawRate = 5.0 deg/s -> raw = (5.0 - (-327.68)) / 0.01 = 33268 */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 32U, 16U, 33268U);
+
+    can_rx_process(&state, CAN_ID_EGO_VEHICLE, frame, 8U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_FLOAT_NEAR(rx.yaw_rate, 5.0F, 0.02F);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX Alert (0x300)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_alert)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    alert_output_t alert = { .alert_type = 3U, .alert_active = 1U, .buzzer_cmd = 4U };
+
+    int32_t rc = can_tx_alert(&alert);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX timeout detection  (FR-CAN-002 acceptance: 60 ms)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_timeout)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* Simulate 6 ticks (60 ms) with no RX */
+    uint8_t i = 0U;
+    for (i = 0U; i < 6U; i++)
+    {
+        can_check_timeout(&state);
+    }
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+    ASSERT_EQ(rx.rx_timeout_flag, 1U);
+}
+
+TEST(test_rx_timeout_reset_on_valid_frame)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* 5 ticks without data */
+    uint8_t i = 0U;
+    for (i = 0U; i < 5U; i++)
+    {
+        can_check_timeout(&state);
+    }
+
+    /* Valid radar frame arrives — should reset counter */
+    uint8_t frame[8] = {0};
+    can_pack_signal(frame, 0U, 16U, 1000U); /* 10m */
+    can_rx_process(&state, CAN_ID_RADAR_TARGET, frame, 8U);
+
+    /* 1 more tick — should NOT be timed out */
+    can_check_timeout(&state);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+    ASSERT_EQ(rx.rx_timeout_flag, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX BrakeCmd encoding  (FR-CAN-003)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_brake_cmd)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    pid_output_t pid = { .brake_pct = 75.0F, .brake_bar = 7.5F };
+    fsm_output_t fsm = {0};
+    fsm.fsm_state   = (uint8_t)FSM_BRAKE_L3;
+    fsm.brake_active = 1U;
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+
+    /* Alive counter should have incremented */
+    ASSERT_EQ(state.alive_counter, 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX FSM State at 50 ms period  (FR-CAN-001)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_fsm_period)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    fsm_output_t fsm = {0};
+    fsm.fsm_state = (uint8_t)FSM_WARNING;
+    fsm.alert_level = 1U;
+
+    /* First 4 ticks: should NOT transmit (return 1 = not due) */
+    int32_t rc = 0;
+    uint8_t i = 0U;
+    for (i = 0U; i < 4U; i++)
+    {
+        rc = can_tx_fsm_state(&state, &fsm);
+        ASSERT_EQ(rc, 1);
+    }
+
+    /* 5th tick: SHOULD transmit */
+    rc = can_tx_fsm_state(&state, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX failure handling
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_send_failure)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+    can_hal_test_force_send_fail(1);
+
+    pid_output_t pid = { .brake_pct = 50.0F, .brake_bar = 5.0F };
+    fsm_output_t fsm = {0};
+    fsm.fsm_state = (uint8_t)FSM_BRAKE_L1;
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_ERR_TX);
+
+    can_hal_test_force_send_fail(0);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  MAIN
+ * ═══════════════════════════════════════════════════════════════════════ */
+int main(void)
+{
+    printf("=== AEB CAN Module — Unit Tests ===\n\n");
+
+    RUN(test_signal_roundtrip);
+    RUN(test_init_success);
+    RUN(test_init_failure);
+    RUN(test_rx_ego_vehicle);
+    RUN(test_rx_yaw_rate);
+    RUN(test_rx_radar_target);
+    RUN(test_rx_driver_input);
+    RUN(test_tx_alert);
+    RUN(test_rx_timeout);
+    RUN(test_rx_timeout_reset_on_valid_frame);
+    RUN(test_tx_brake_cmd);
+    RUN(test_tx_fsm_period);
+    RUN(test_tx_send_failure);
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n",
+           tests_run, tests_passed, tests_failed);
+
+    return (tests_failed > 0) ? 1 : 0;
+}

--- a/tests/test_decision.c
+++ b/tests/test_decision.c
@@ -1,0 +1,217 @@
+/**
+ * @file test_decision.c
+ * @brief Unit tests for decision logic (TTC + FSM)
+ * @author Lourenço Jamba Mphili
+ * @requirements FR-DEC-001 to FR-DEC-011, FR-FSM-001 to FR-FSM-006
+ */
+
+#include "aeb_ttc.h"
+#include "aeb_fsm.h"
+#include <stdio.h>
+#include <math.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST_ASSERT(condition, msg) \
+    do { \
+        if (condition) { \
+            printf("  ✅ PASS: %s\n", msg); \
+            tests_passed++; \
+        } else { \
+            printf("  ❌ FAIL: %s\n", msg); \
+            tests_failed++; \
+        } \
+    } while(0)
+
+/* ============================================================ */
+/* TTC Tests (FR-DEC-001, FR-DEC-002, FR-DEC-003)               */
+/* ============================================================ */
+
+static void test_ttc_normal(void)
+{
+    perception_output_t perc = {
+        .distance = 50.0f,
+        .v_ego = 20.0f,
+        .v_rel = 10.0f
+    };
+    ttc_output_t ttc;
+    ttc_process(&perc, &ttc);
+    TEST_ASSERT(fabsf(ttc.ttc - 5.0f) < 0.05f, "TTC normal closing (5.0s)");
+}
+
+static void test_ttc_critical(void)
+{
+    perception_output_t perc = {
+        .distance = 10.0f,
+        .v_ego = 20.0f,
+        .v_rel = 20.0f
+    };
+    ttc_output_t ttc;
+    ttc_process(&perc, &ttc);
+    TEST_ASSERT(fabsf(ttc.ttc - 0.5f) < 0.05f, "TTC critical (0.5s)");
+}
+
+static void test_ttc_not_closing(void)
+{
+    perception_output_t perc = {
+        .distance = 50.0f,
+        .v_ego = 10.0f,
+        .v_rel = 0.4f
+    };
+    ttc_output_t ttc;
+    ttc_process(&perc, &ttc);
+    TEST_ASSERT(ttc.ttc == 10.0f, "TTC not closing (max 10.0s)");
+}
+
+static void test_dbrake_normal(void)
+{
+    float32_t d = d_brake_calc(13.89f);
+    float32_t expected = (13.89f * 13.89f) / 12.0f;
+    TEST_ASSERT(fabsf(d - expected) < 0.5f, "Braking distance at 50 km/h");
+}
+
+static void test_dbrake_zero(void)
+{
+    float32_t d = d_brake_calc(0.0f);
+    TEST_ASSERT(d == 0.0f, "Braking distance at zero speed");
+}
+
+/* ============================================================ */
+/* FSM Tests (FR-FSM-001 to FR-FSM-006)                         */
+/* ============================================================ */
+
+static void test_fsm_initial(void)
+{
+    fsm_output_t fsm_out;
+    fsm_init(&fsm_out);
+    TEST_ASSERT(fsm_out.fsm_state == FSM_STANDBY, "FSM initial state = STANDBY");
+}
+
+static void test_fsm_fault(void)
+{
+    perception_output_t perc = {
+        .distance = 50.0f,
+        .v_ego = 15.0f,
+        .v_rel = 5.0f,
+        .fault_flag = 0U
+    };
+    driver_input_t driver = {
+        .brake_pedal = 0U,
+        .aeb_enabled = 1U
+    };
+    ttc_output_t ttc = {
+        .ttc = 2.0f,
+        .is_closing = 1U
+    };
+    fsm_output_t fsm_out;
+    
+    fsm_init(&fsm_out);
+    fsm_step(0.01f, &perc, &driver, &ttc, &fsm_out);
+    
+    /* Inject fault */
+    perc.fault_flag = 1U;
+    fsm_step(0.01f, &perc, &driver, &ttc, &fsm_out);
+    
+    TEST_ASSERT(fsm_out.fsm_state == FSM_OFF, "FSM goes to OFF on fault");
+}
+
+static void test_fsm_override(void)
+{
+    perception_output_t perc = {
+        .distance = 30.0f,
+        .v_ego = 15.0f,
+        .v_rel = 15.0f,
+        .fault_flag = 0U
+    };
+    driver_input_t driver = {
+        .brake_pedal = 0U,
+        .accel_pedal = 0U,
+        .steering_angle = 0.0f,
+        .aeb_enabled = 1U
+    };
+    ttc_output_t ttc = {
+        .ttc = 1.5f,
+        .d_brake = 18.75f,
+        .is_closing = 1U
+    };
+    fsm_output_t fsm_out;
+    int i;
+    
+    fsm_init(&fsm_out);
+    
+    /* Run cycles to enter braking state */
+    for (i = 0; i < 100; i++)
+    {
+        fsm_step(0.01f, &perc, &driver, &ttc, &fsm_out);
+    }
+    
+    /* Apply brake pedal */
+    driver.brake_pedal = 1U;
+    fsm_step(0.01f, &perc, &driver, &ttc, &fsm_out);
+    
+    TEST_ASSERT(fsm_out.fsm_state == FSM_STANDBY, "Driver override goes to STANDBY");
+}
+
+/* ============================================================ */
+/* Parameter Validation (SRS Table 10)                          */
+/* ============================================================ */
+
+static void test_deceleration_values(void)
+{
+    /* Test deceleration values - values are defined in aeb_config.h */
+    /* DECEL_L1 = 2.0f, DECEL_L2 = 4.0f, DECEL_L3 = 6.0f */
+    
+    int all_pass = 1;
+    
+    /* Verify that constants exist and have correct values */
+    if (DECEL_L1 != 2.0f) all_pass = 0;
+    if (DECEL_L2 != 4.0f) all_pass = 0;
+    if (DECEL_L3 != 6.0f) all_pass = 0;
+    
+    TEST_ASSERT(all_pass == 1, "Deceleration values (2/4/6 m/s² per Table 10)");
+}
+
+/* ============================================================ */
+/* Main Function                                                */
+/* ============================================================ */
+
+int main(void)
+{
+    printf("\n========================================\n");
+    printf("Decision Logic Tests (TTC + FSM)\n");
+    printf("Author: Lourenço Jamba Mphili\n");
+    printf("Requirements: FR-DEC-001 to FR-DEC-011\n");
+    printf("              FR-FSM-001 to FR-FSM-006\n");
+    printf("========================================\n\n");
+    
+    printf("--- TTC Tests (FR-DEC-001, FR-DEC-002, FR-DEC-003) ---\n");
+    test_ttc_normal();
+    test_ttc_critical();
+    test_ttc_not_closing();
+    test_dbrake_normal();
+    test_dbrake_zero();
+    
+    printf("\n--- FSM Tests (FR-FSM-001 to FR-FSM-006) ---\n");
+    test_fsm_initial();
+    test_fsm_fault();
+    test_fsm_override();
+    
+    printf("\n--- Parameter Validation (SRS Table 10) ---\n");
+    test_deceleration_values();
+    
+    printf("\n========================================\n");
+    printf("RESULTS: %d passed, %d failed\n", tests_passed, tests_failed);
+    printf("========================================\n");
+    
+    if (tests_failed == 0)
+    {
+        printf("\n✅ ALL TESTS PASSED - Decision Logic ready for integration\n");
+    }
+    else
+    {
+        printf("\n❌ %d TEST(S) FAILED - Review implementation\n", tests_failed);
+    }
+    
+    return (tests_failed == 0) ? 0 : 1;
+}

--- a/tests/test_smoke.c
+++ b/tests/test_smoke.c
@@ -1,0 +1,78 @@
+/**
+ * @file  test_smoke.c
+ * @brief Smoke tests — verify all stubs compile and basic init works.
+ *
+ * This is the baseline CI test. Each team member adds their own
+ * test file (test_perception.c, test_fsm.c, etc.) via PR.
+ */
+
+#include "aeb_types.h"
+#include "aeb_config.h"
+#include "aeb_can.h"
+#include <stdio.h>
+#include <string.h>
+
+static int32_t tests_run    = 0;
+static int32_t tests_passed = 0;
+static int32_t tests_failed = 0;
+
+#define ASSERT_EQ(a, b) do { \
+    if ((a) == (b)) { tests_passed++; } \
+    else { printf("  FAIL: %s:%d  %s != %s\n", __FILE__, __LINE__, #a, #b); tests_failed++; } \
+    tests_run++; \
+} while (0)
+
+#define TEST(name) static void name(void)
+#define RUN(name) do { printf("  [TEST] %s\n", #name); name(); } while (0)
+
+/* Verify aeb_types.h structs can be instantiated */
+TEST(test_types_instantiation)
+{
+    perception_output_t perc = {0};
+    ttc_output_t        ttc  = {0};
+    fsm_output_t        fsm  = {0};
+    pid_output_t        pid  = {0};
+    alert_output_t      alrt = {0};
+    driver_input_t      drv  = {0};
+
+    ASSERT_EQ(perc.fault_flag, 0U);
+    ASSERT_EQ(ttc.is_closing, 0U);
+    ASSERT_EQ(fsm.fsm_state, 0U);
+    ASSERT_EQ(pid.brake_pct, 0.0F);
+    ASSERT_EQ(alrt.alert_type, 0U);
+    ASSERT_EQ(drv.aeb_enabled, 0U);
+}
+
+/* Verify CAN init stub returns OK */
+TEST(test_can_init_stub)
+{
+    can_state_t state;
+    int32_t rc = can_init(&state);
+    ASSERT_EQ(rc, CAN_OK);
+}
+
+/* Verify FSM enum values match specification */
+TEST(test_fsm_enum_values)
+{
+    ASSERT_EQ((int)FSM_OFF, 0);
+    ASSERT_EQ((int)FSM_STANDBY, 1);
+    ASSERT_EQ((int)FSM_WARNING, 2);
+    ASSERT_EQ((int)FSM_BRAKE_L1, 3);
+    ASSERT_EQ((int)FSM_BRAKE_L2, 4);
+    ASSERT_EQ((int)FSM_BRAKE_L3, 5);
+    ASSERT_EQ((int)FSM_POST_BRAKE, 6);
+}
+
+int main(void)
+{
+    printf("=== AEB Smoke Tests ===\n\n");
+
+    RUN(test_types_instantiation);
+    RUN(test_can_init_stub);
+    RUN(test_fsm_enum_values);
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n",
+           tests_run, tests_passed, tests_failed);
+
+    return (tests_failed > 0) ? 1 : 0;
+}


### PR DESCRIPTION
# Summary
- Implement TTC (Time-to-Collision) calculation using v_rel from contract (FR-DEC-001/002/003)
- Implement 7-state AEB Finite State Machine (OFF, STANDBY, WARNING, BRAKE_L1, BRAKE_L2, BRAKE_L3, POST_BRAKE)
- Add unit tests (test_decision.c) that test real code (not local copies)
- Ensure STANDBY always goes through WARNING before BRAKE (FR-DEC-011)
- Deceleration values: 2/4/6 m/s² per SRS Table 10
- MISRA C:2012 compliant (single return points, no bool, no unused includes)

# Related Issue
Closes #28
Closes #29

# Change Type
- [x] feat
- [ ] fix
- [ ] docs
- [x] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [x] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [x] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-DEC-001 to FR-DEC-011
- FR-FSM-001 to FR-FSM-006

## Non-Functional Requirements
- NFR-COD-001 to NFR-COD-007 (MISRA C:2012)
- NFR-POR-002 (calibration parameters in aeb_config.h)

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes (pending)
- [x] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated
