### PR TITLE
feat: implement perception module (FR-PER-001..008)

### DIFF
--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -74,27 +74,27 @@
 #define UDS_DID_BRAKE_PRESS   0xF102U    /**< DID — Brake pressure    */
 #define UDS_ROUTINE_AEB       0x0301U    /**< RID — AEB enable/disable*/
 
-/* Fault detection (FR-PER-006, FR-PER-007) */
+/* ===== Fault detection (FR-PER-006, FR-PER-007) ===== */
 #define RADAR_DIST_MIN      0.5f    /* m                          */
 #define RADAR_DIST_MAX      200.0f  /* m                          */
 #define LIDAR_DIST_MIN      1.0f    /* m                          */
 #define LIDAR_DIST_MAX      100.0f  /* m                          */
 #define MAX_REL_VEL         50.0f   /* m/s                        */
 
-/* Kalman measurement noise (chart_41) */
+/* ===== Kalman measurement noise ===== */
 #define KALMAN_R_LIDAR      0.0025f /* m^2                        */
 #define KALMAN_R_RADAR_D    0.09f   /* m^2                        */
 #define KALMAN_R_RADAR_V    0.01f   /* (m/s)^2                    */
 
-/* Kalman process noise */
+/* ===== Kalman process noise ===== */
 #define KALMAN_Q_D          1e-4f   /* m^2                        */
 #define KALMAN_Q_V          1e-5f   /* (m/s)^2                    */
 
-/* Kalman initial covariance */
+/* ===== Kalman initial covariance ===== */
 #define KALMAN_P0_D         1.0f    /* m^2                        */
 #define KALMAN_P0_V         0.25f   /* (m/s)^2                    */
 
-/* Output clamping */
+/* ===== Output clamping ===== */
 #define DIST_MAX_OUTPUT     300.0f  /* m                          */
 #define DIST_MIN_OUTPUT     0.5f    /* m                          */
 

--- a/include/aeb_config.h
+++ b/include/aeb_config.h
@@ -74,4 +74,28 @@
 #define UDS_DID_BRAKE_PRESS   0xF102U    /**< DID — Brake pressure    */
 #define UDS_ROUTINE_AEB       0x0301U    /**< RID — AEB enable/disable*/
 
+/* Fault detection (FR-PER-006, FR-PER-007) */
+#define RADAR_DIST_MIN      0.5f    /* m                          */
+#define RADAR_DIST_MAX      200.0f  /* m                          */
+#define LIDAR_DIST_MIN      1.0f    /* m                          */
+#define LIDAR_DIST_MAX      100.0f  /* m                          */
+#define MAX_REL_VEL         50.0f   /* m/s                        */
+
+/* Kalman measurement noise (chart_41) */
+#define KALMAN_R_LIDAR      0.0025f /* m^2                        */
+#define KALMAN_R_RADAR_D    0.09f   /* m^2                        */
+#define KALMAN_R_RADAR_V    0.01f   /* (m/s)^2                    */
+
+/* Kalman process noise */
+#define KALMAN_Q_D          1e-4f   /* m^2                        */
+#define KALMAN_Q_V          1e-5f   /* (m/s)^2                    */
+
+/* Kalman initial covariance */
+#define KALMAN_P0_D         1.0f    /* m^2                        */
+#define KALMAN_P0_V         0.25f   /* (m/s)^2                    */
+
+/* Output clamping */
+#define DIST_MAX_OUTPUT     300.0f  /* m                          */
+#define DIST_MIN_OUTPUT     0.5f    /* m                          */
+
 #endif /* AEB_CONFIG_H */

--- a/include/aeb_perception.h
+++ b/include/aeb_perception.h
@@ -1,0 +1,37 @@
+/**
+ * @file  aeb_perception.h
+ * @brief Public API for the AEB Perception module.
+ */
+
+#ifndef AEB_PERCEPTION_H
+#define AEB_PERCEPTION_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief One frame of raw sensor data (from CAN Bus or test harness).
+ *
+ * Fields:
+ *   radar_d     Radar-measured distance to obstacle [m].
+ *   radar_vr    Radar-measured relative velocity (positive = closing) [m/s].
+ *   lidar_d     LiDAR-measured distance to obstacle [m].
+ *   v_ego       Ego-vehicle speed from wheel/IMU sensors [m/s].
+ *   can_timeout Non-zero if the CAN frame was not received within deadline.
+ *   fi          Fault-injection flag for V&V (0 = normal, 1 = force fault).
+ */
+typedef struct {
+    float32_t radar_d;
+    float32_t radar_vr;
+    float32_t lidar_d;
+    float32_t v_ego;
+    uint8_t   can_timeout;
+    uint8_t   fi;
+} raw_sensor_input_t;
+
+/** Reset all internal state. Call once before first perception_step(). */
+void perception_init(void);
+
+/** Execute one perception cycle (10 ms). */
+void perception_step(const raw_sensor_input_t *in, perception_output_t *out);
+
+#endif /* AEB_PERCEPTION_H */

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -109,4 +109,9 @@ typedef enum
     FSM_POST_BRAKE = 6
 } fsm_state_e;
 
+/* fault_flag bit positions */
+#define AEB_FAULT_LIDAR    ((uint8_t)0x01U)
+#define AEB_FAULT_RADAR    ((uint8_t)0x02U)
+#define AEB_FAULT_CAN_TO   ((uint8_t)0x80U)
+
 #endif /* AEB_TYPES_H */

--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -1,35 +1,318 @@
 /**
  * @file  aeb_perception.c
- * @brief Perception and Sensor Fusion — STUB (Task A placeholder).
- *
- * This file will be replaced by Eryca's implementation.
- * Provides empty function bodies so the project compiles and CI passes.
+ * @brief AEB Perception module implementation.
  */
 
-#include "aeb_types.h"
+#include "aeb_perception.h"
+#include "aeb_config.h"
+#include <stddef.h>
+
+#define FABSF(x) (((x) < 0.0f) ? -(x) : (x))
+
+static float32_t clampf(float32_t v, float32_t lo, float32_t hi)
+{
+    if (v < lo) { return lo; }
+    if (v > hi) { return hi; }
+    return v;
+}
+
+/* --- LiDAR fault detector (chart_26) --- */
+
+typedef struct {
+    float32_t prev_d;
+    uint8_t   ctr;
+    uint8_t   is_first;
+} lidar_state_t;
+
+static lidar_state_t s_lidar;
+
+static void lidar_state_reset(lidar_state_t *s)
+{
+    s->prev_d   = 0.0f;
+    s->ctr      = 0U;
+    s->is_first = 1U;
+}
+
+static uint8_t lidar_fault_detect(float32_t d_l)
+{
+    uint8_t bad;
+    uint8_t fault;
+
+    bad = ((d_l < LIDAR_DIST_MIN) || (d_l > LIDAR_DIST_MAX)) ? 1U : 0U;
+
+    if ((s_lidar.is_first == 0U) && (bad == 0U)) {
+        if (FABSF(d_l - s_lidar.prev_d) > DIST_ROC_LIMIT) {
+            bad = 1U;
+        }
+    }
+
+    if (bad != 0U) {
+        if (s_lidar.ctr < 255U) { s_lidar.ctr++; }
+    } else {
+        s_lidar.ctr = 0U;
+    }
+
+    s_lidar.prev_d   = d_l;
+    s_lidar.is_first = 0U;
+
+    fault = (s_lidar.ctr >= (uint8_t)SENSOR_FAULT_CYCLES) ? 1U : 0U;
+    return fault;
+}
+
+/* --- Radar fault detector (chart_33) --- */
+
+typedef struct {
+    float32_t prev_d;
+    float32_t prev_vr;
+    uint8_t   ctr;
+    uint8_t   is_first;
+} radar_state_t;
+
+static radar_state_t s_radar;
+
+static void radar_state_reset(radar_state_t *s)
+{
+    s->prev_d   = 0.0f;
+    s->prev_vr  = 0.0f;
+    s->ctr      = 0U;
+    s->is_first = 1U;
+}
+
+static uint8_t radar_fault_detect(float32_t d_r, float32_t vr_r)
+{
+    uint8_t bad;
+    uint8_t fault;
+
+    bad = ((d_r < RADAR_DIST_MIN) || (d_r > RADAR_DIST_MAX) ||
+           (FABSF(vr_r) > MAX_REL_VEL)) ? 1U : 0U;
+
+    if ((s_radar.is_first == 0U) && (bad == 0U)) {
+        if ((FABSF(d_r  - s_radar.prev_d)  > DIST_ROC_LIMIT) ||
+            (FABSF(vr_r - s_radar.prev_vr) > VEL_ROC_LIMIT)) {
+            bad = 1U;
+        }
+    }
+
+    if (bad != 0U) {
+        if (s_radar.ctr < 255U) { s_radar.ctr++; }
+    } else {
+        s_radar.ctr = 0U;
+    }
+
+    s_radar.prev_d   = d_r;
+    s_radar.prev_vr  = vr_r;
+    s_radar.is_first = 0U;
+
+    fault = (s_radar.ctr >= (uint8_t)SENSOR_FAULT_CYCLES) ? 1U : 0U;
+    return fault;
+}
+
+/* --- Kalman fusion (chart_41) ---
+ *
+ * State: x = [distance, v_rel]'
+ * F = | 1  -dt |    Q = diag(Q_d, Q_v)
+ *     | 0   1  |
+ *
+ * Sequential update:
+ *   1) LiDAR:  H = [1,0],  R = R_lidar
+ *   2) Radar:  H = I_2x2,  R = diag(R_radar_d, R_radar_v)
+ *
+ * Confidence: both=1.0, radar-only=0.7, lidar-only=0.5, none=0.0
+ *             scaled by max(0, 1 - tr(P)/2)
+ */
+
+typedef struct {
+    float32_t x[2];
+    float32_t P[2][2];
+    uint8_t   initialized;
+} kalman_state_t;
+
+static kalman_state_t s_kalman;
+
+static void kalman_state_reset(kalman_state_t *s)
+{
+    s->x[0] = 0.0f;
+    s->x[1] = 0.0f;
+    s->P[0][0] = KALMAN_P0_D;  s->P[0][1] = 0.0f;
+    s->P[1][0] = 0.0f;         s->P[1][1] = KALMAN_P0_V;
+    s->initialized = 0U;
+}
+
+static void kalman_fusion(
+    float32_t d_l, float32_t d_r, float32_t vr_r,
+    uint8_t l_fault, uint8_t r_fault, uint8_t fi,
+    float32_t *out_d, float32_t *out_v, float32_t *out_conf)
+{
+    uint8_t l_ok = ((l_fault == 0U) && (fi == 0U)) ? 1U : 0U;
+    uint8_t r_ok = ((r_fault == 0U) && (fi == 0U)) ? 1U : 0U;
+
+    /* Seed state on first call: x = [d_r, vr_r] */
+    if (s_kalman.initialized == 0U) {
+        s_kalman.x[0] = d_r;
+        s_kalman.x[1] = vr_r;
+        s_kalman.initialized = 1U;
+    }
+
+    /* --- PREDICT: xp = F*x, Pp = F*P*F' + Q --- */
+    float32_t dt = AEB_DT;
+    float32_t xp0 = s_kalman.x[0] - (dt * s_kalman.x[1]);
+    float32_t xp1 = s_kalman.x[1];
+
+    float32_t A00 = s_kalman.P[0][0] - (dt * s_kalman.P[1][0]);
+    float32_t A01 = s_kalman.P[0][1] - (dt * s_kalman.P[1][1]);
+    float32_t A10 = s_kalman.P[1][0];
+    float32_t A11 = s_kalman.P[1][1];
+
+    float32_t Pp00 = (A00 - (dt * A01)) + KALMAN_Q_D;
+    float32_t Pp01 = A01;
+    float32_t Pp10 = A10 - (dt * A11);
+    float32_t Pp11 = A11 + KALMAN_Q_V;
+
+    /* --- UPDATE 1: LiDAR (H=[1,0], scalar) --- */
+    float32_t x1_0 = xp0;
+    float32_t x1_1 = xp1;
+    float32_t P1_00 = Pp00;
+    float32_t P1_01 = Pp01;
+    float32_t P1_10 = Pp10;
+    float32_t P1_11 = Pp11;
+
+    if (l_ok != 0U) {
+        float32_t S_l  = Pp00 + KALMAN_R_LIDAR;
+        float32_t K0   = Pp00 / S_l;
+        float32_t K1   = Pp10 / S_l;
+        float32_t innov = d_l - xp0;
+
+        x1_0 = xp0 + (K0 * innov);
+        x1_1 = xp1 + (K1 * innov);
+
+        float32_t imK0 = 1.0f - K0;
+        P1_00 = imK0 * Pp00;
+        P1_01 = imK0 * Pp01;
+        P1_10 = (-K1 * Pp00) + Pp10;
+        P1_11 = (-K1 * Pp01) + Pp11;
+    }
+
+    /* --- UPDATE 2: Radar (H=I_2x2, 2x2 inverse) --- */
+    float32_t x2_0 = x1_0;
+    float32_t x2_1 = x1_1;
+    float32_t P2_00 = P1_00;
+    float32_t P2_01 = P1_01;
+    float32_t P2_10 = P1_10;
+    float32_t P2_11 = P1_11;
+
+    if (r_ok != 0U) {
+        float32_t S00 = P1_00 + KALMAN_R_RADAR_D;
+        float32_t S01 = P1_01;
+        float32_t S10 = P1_10;
+        float32_t S11 = P1_11 + KALMAN_R_RADAR_V;
+
+        float32_t det = (S00 * S11) - (S01 * S10);
+
+        if (FABSF(det) > 1e-9f) {
+            float32_t inv_det = 1.0f / det;
+            float32_t Si00 =  S11 * inv_det;
+            float32_t Si01 = -S01 * inv_det;
+            float32_t Si10 = -S10 * inv_det;
+            float32_t Si11 =  S00 * inv_det;
+
+            float32_t K00 = (P1_00 * Si00) + (P1_01 * Si10);
+            float32_t K01 = (P1_00 * Si01) + (P1_01 * Si11);
+            float32_t K10 = (P1_10 * Si00) + (P1_11 * Si10);
+            float32_t K11 = (P1_10 * Si01) + (P1_11 * Si11);
+
+            float32_t inn0 = d_r  - x1_0;
+            float32_t inn1 = vr_r - x1_1;
+
+            x2_0 = x1_0 + (K00 * inn0) + (K01 * inn1);
+            x2_1 = x1_1 + (K10 * inn0) + (K11 * inn1);
+
+            float32_t imK00 = 1.0f - K00;
+            float32_t imK11 = 1.0f - K11;
+
+            P2_00 = (imK00 * P1_00) + ((-K01) * P1_10);
+            P2_01 = (imK00 * P1_01) + ((-K01) * P1_11);
+            P2_10 = ((-K10) * P1_00) + (imK11 * P1_10);
+            P2_11 = ((-K10) * P1_01) + (imK11 * P1_11);
+        }
+    }
+
+    /* Persist state */
+    s_kalman.x[0]    = x2_0;
+    s_kalman.x[1]    = x2_1;
+    s_kalman.P[0][0] = P2_00;
+    s_kalman.P[0][1] = P2_01;
+    s_kalman.P[1][0] = P2_10;
+    s_kalman.P[1][1] = P2_11;
+
+    /* Confidence */
+    if ((l_ok == 0U) && (r_ok == 0U)) {
+        *out_conf = 0.0f;
+    } else {
+        float32_t base;
+        if ((l_ok != 0U) && (r_ok != 0U)) {
+            base = 1.0f;
+        } else if (r_ok != 0U) {
+            base = 0.7f;
+        } else {
+            base = 0.5f;
+        }
+        float32_t trace_P = P2_00 + P2_11;
+        float32_t quality = 1.0f - (trace_P / 2.0f);
+        if (quality < 0.0f) { quality = 0.0f; }
+        *out_conf = base * quality;
+    }
+
+    *out_d = clampf(x2_0, DIST_MIN_OUTPUT, DIST_MAX_OUTPUT);
+    *out_v = clampf(x2_1, -MAX_REL_VEL,   MAX_REL_VEL);
+}
+
+/* --- Public API --- */
 
 void perception_init(void)
 {
-    /* STUB — Task A (Eryca) */
+    lidar_state_reset(&s_lidar);
+    radar_state_reset(&s_radar);
+    kalman_state_reset(&s_kalman);
 }
 
-void perception_step(const float32_t d_radar,
-                     const float32_t vr_radar,
-                     const float32_t d_lidar,
-                     const float32_t ve_ego,
-                     perception_output_t *out)
+void perception_step(const raw_sensor_input_t *in, perception_output_t *out)
 {
-    (void)d_radar;
-    (void)vr_radar;
-    (void)d_lidar;
-    (void)ve_ego;
+    uint8_t   l_fault;
+    uint8_t   r_fault;
+    float32_t fused_d;
+    float32_t fused_v;
+    float32_t conf;
 
-    if (out != (void *)0)
-    {
-        out->distance   = 0.0F;
-        out->v_ego      = 0.0F;
-        out->v_rel      = 0.0F;
-        out->confidence = 0.0F;
-        out->fault_flag = 0U;
+    out->v_ego      = in->v_ego;
+    out->fault_flag = 0U;
+
+    /* CAN timeout: hold last Kalman estimate, flag all faults */
+    if (in->can_timeout != 0U) {
+        out->fault_flag = AEB_FAULT_LIDAR | AEB_FAULT_RADAR | AEB_FAULT_CAN_TO;
+        out->distance   = clampf(s_kalman.x[0], DIST_MIN_OUTPUT, DIST_MAX_OUTPUT);
+        out->v_rel      = clampf(s_kalman.x[1], -MAX_REL_VEL, MAX_REL_VEL);
+        out->confidence = 0.0f;
+        return;
     }
+
+    /* Sensor fault detection */
+    l_fault = lidar_fault_detect(in->lidar_d);
+    r_fault = radar_fault_detect(in->radar_d, in->radar_vr);
+
+    if (l_fault != 0U) { out->fault_flag |= AEB_FAULT_LIDAR; }
+    if (r_fault != 0U) { out->fault_flag |= AEB_FAULT_RADAR; }
+
+    /* Kalman fusion (runs even if both faulty for dead-reckoning) */
+    kalman_fusion(in->lidar_d, in->radar_d, in->radar_vr,
+                  l_fault, r_fault, in->fi,
+                  &fused_d, &fused_v, &conf);
+
+    /* Fault injection propagation (NFR-SAF-005) */
+    if (in->fi != 0U) {
+        out->fault_flag |= AEB_FAULT_LIDAR | AEB_FAULT_RADAR;
+    }
+
+    out->distance   = fused_d;
+    out->v_rel      = fused_v;
+    out->confidence = conf;
 }

--- a/tests/test_perception.c
+++ b/tests/test_perception.c
@@ -1,0 +1,570 @@
+/**
+ * @file    test_perception.c
+ * @brief   Unit tests for the AEB Perception module (Task A).
+ *
+ * Compile and run on PC (no Zephyr / hardware dependency):
+ *
+ *   gcc -Wall -Wextra -I../include \
+ *       ../src/perception/aeb_perception.c test_perception.c \
+ *       -o test_perception -lm
+ *   ./test_perception
+ *
+ * Each test prints PASS or FAIL with a short description.
+ * Exit code is 0 if all tests pass, 1 otherwise.
+ *
+ * Requirements verified: Requirements: FR-PER-001, FR-PER-002, FR-PER-003, FR-PER-006, FR-PER-007, NFR-COD-006, NFR-COD-007
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "aeb_types.h"
+#include "aeb_config.h"
+#include "aeb_perception.h"
+
+/* =========================================================================
+ * Mini test framework
+ * ====================================================================== */
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define CHECK(cond, name)                                      \
+    do {                                                       \
+        if (cond) {                                            \
+            printf("[PASS] %s\n", (name));                     \
+            g_pass++;                                          \
+        } else {                                               \
+            printf("[FAIL] %s  (line %d)\n", (name), __LINE__);\
+            g_fail++;                                          \
+        }                                                      \
+    } while (0)
+
+#define FABSF_T(x) (((x) < 0.0f) ? -(x) : (x))
+
+/* =========================================================================
+ * Helper: build a "good" nominal input frame
+ * ====================================================================== */
+static raw_sensor_input_t make_good_input(void)
+{
+    raw_sensor_input_t in;
+    in.radar_d     = 30.0f;
+    in.radar_vr    = 5.0f;
+    in.lidar_d     = 30.2f;
+    in.v_ego       = 20.0f;
+    in.can_timeout = 0U;
+    in.fi          = 0U;
+    return in;
+}
+
+/* =========================================================================
+ * TEST 1 — FR-PER-006, FR-PER-007
+ * LiDAR fault must NOT be latched on fewer than SENSOR_FAULT_CYCLES bad frames.
+ * ====================================================================== */
+static void test_lidar_no_fault_before_latch(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+
+    /* Feed (SENSOR_FAULT_CYCLES - 1) clearly out-of-range LiDAR samples */
+    in.lidar_d = 999.0f;   /* above LIDAR_DIST_MAX = 100 m */
+    for (i = 0; i < (int)SENSOR_FAULT_CYCLES - 1; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) == 0U,
+          "LiDAR: no fault before latch cycle");
+}
+
+/* =========================================================================
+ * TEST 2 — FR-PER-006, FR-PER-007
+ * LiDAR fault IS latched on exactly SENSOR_FAULT_CYCLES consecutive bad frames.
+ * ====================================================================== */
+static void test_lidar_fault_latches_at_cycle3(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+    in.lidar_d = 999.0f;
+
+    for (i = 0; i < (int)SENSOR_FAULT_CYCLES; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) != 0U,
+          "LiDAR: fault latches at cycle 3");
+}
+
+/* =========================================================================
+ * TEST 3 — FR-PER-006, FR-PER-007
+ * LiDAR counter resets when a good frame is received before latch.
+ * ====================================================================== */
+static void test_lidar_counter_resets_on_good_frame(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+
+    /* 2 bad frames: just above LIDAR_DIST_MAX (100 m), values close together
+     * so that later the ROC from bad→good doesn't re-trigger. */
+    in.lidar_d = 105.0f;   /* out of range; ctr=1, prev_d=105 */
+    perception_step(&in, &out);
+    in.lidar_d = 104.0f;   /* out of range; ROC |104-105|=1≤10; ctr=2, prev_d=104 */
+    perception_step(&in, &out);
+
+    /* 1 good frame close to prev_d: in range AND ROC OK → counter resets */
+    in.lidar_d = 97.0f;    /* in range [1,100]; ROC |97-104|=7≤10; ctr=0 */
+    perception_step(&in, &out);
+
+    /* 2 more bad frames (just above max, incremental) → ctr reaches 2, not 3 */
+    in.lidar_d = 105.0f;   /* out of range; ROC |105-97|=8≤10; ctr=1 */
+    perception_step(&in, &out);
+    in.lidar_d = 106.0f;   /* out of range; ROC |106-105|=1≤10; ctr=2 */
+    perception_step(&in, &out);
+
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) == 0U,
+          "LiDAR: counter resets on good frame before latch");
+}
+
+/* =========================================================================
+ * TEST 4 — FR-PER-006, FR-PER-007
+ * Radar fault latches at exactly SENSOR_FAULT_CYCLES out-of-range frames.
+ * ====================================================================== */
+static void test_radar_fault_latches_at_cycle3(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+    in.radar_d = 999.0f;   /* above RADAR_DIST_MAX = 200 m */
+
+    for (i = 0; i < (int)SENSOR_FAULT_CYCLES; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK((out.fault_flag & AEB_FAULT_RADAR) != 0U,
+          "Radar: fault latches at cycle 3");
+}
+
+/* =========================================================================
+ * TEST 5 — FR-PER-006, FR-PER-007
+ * Radar fault NOT latched when relative velocity exceeds MAX_REL_VEL only
+ * once (just one bad cycle, not three).
+ * ====================================================================== */
+static void test_radar_no_fault_single_bad_vr(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+
+    /* One cycle with |vr| > 50 m/s */
+    in.radar_vr = 60.0f;
+    perception_step(&in, &out);
+
+    /* Two good cycles */
+    in.radar_vr = 5.0f;
+    perception_step(&in, &out);
+    perception_step(&in, &out);
+
+    CHECK((out.fault_flag & AEB_FAULT_RADAR) == 0U,
+          "Radar: no fault on single bad relative velocity");
+}
+
+/* =========================================================================
+ * TEST 6 — FR-PER-007
+ * CAN timeout sets AEB_FAULT_CAN_TO and both sensor fault bits.
+ * ====================================================================== */
+static void test_can_timeout_sets_fault_flags(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+
+    /* Warm up with a few good cycles first */
+    in = make_good_input();
+    perception_step(&in, &out);
+    perception_step(&in, &out);
+
+    /* Now simulate CAN timeout */
+    in.can_timeout = 1U;
+    perception_step(&in, &out);
+
+    CHECK((out.fault_flag & AEB_FAULT_CAN_TO)  != 0U, "CAN timeout: bit CAN_TO set");
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR)   != 0U, "CAN timeout: bit LIDAR set");
+    CHECK((out.fault_flag & AEB_FAULT_RADAR)   != 0U, "CAN timeout: bit RADAR set");
+    CHECK(out.confidence == 0.0f,                      "CAN timeout: confidence = 0");
+}
+
+/* =========================================================================
+ * TEST 7 — FR-PER-001, FR-PER-003
+ * Kalman output converges towards true distance in ~50 cycles.
+ * Both sensors report 30 m; expect fused distance within 0.5 m of 30.
+ * ====================================================================== */
+static void test_kalman_convergence(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+    in.radar_d  = 30.0f;
+    in.radar_vr = 0.0f;   /* stationary target */
+    in.lidar_d  = 30.0f;
+
+    for (i = 0; i < 50; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK(FABSF_T(out.distance - 30.0f) < 0.5f,
+          "Kalman: converges to 30 m within 50 cycles");
+}
+
+/* =========================================================================
+ * TEST 8 — FR-PER-001
+ * Output distance is clamped to DIST_MIN_OUTPUT when Kalman state is near 0.
+ * ====================================================================== */
+static void test_output_clamp_min_distance(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+
+    /* Drive sensors towards a very small distance */
+    in.radar_d  = 0.3f;   /* below RADAR_DIST_MIN so radar faults eventually */
+    in.lidar_d  = 0.5f;   /* below LIDAR_DIST_MIN (1.0 m), triggers LiDAR fault */
+    in.radar_vr = 0.0f;
+
+    /* Run 5 cycles — Kalman state pulled towards 0.5 m */
+    for (i = 0; i < 5; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK(out.distance >= DIST_MIN_OUTPUT,
+          "Output: distance clamped to >= DIST_MIN_OUTPUT");
+}
+
+/* =========================================================================
+ * TEST 9 — FR-PER-001
+ * Output distance clamped to DIST_MAX_OUTPUT when Kalman state is very large.
+ * ====================================================================== */
+static void test_output_clamp_max_distance(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+
+    /* Drive sensors towards a very large distance */
+    in.radar_d  = 199.0f;
+    in.lidar_d  = 99.0f;
+    in.radar_vr = -30.0f;  /* receding target */
+
+    for (i = 0; i < 50; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK(out.distance <= DIST_MAX_OUTPUT,
+          "Output: distance clamped to <= DIST_MAX_OUTPUT");
+}
+
+/* =========================================================================
+ * TEST 10 — FR-PER-007, NFR-SAF-005
+ * Fault injection (fi=1) disables both sensors inside the Kalman.
+ * V&V criterion: "Inject fault_inj → fault_flag=1 within 30 ms".
+ * chart_41: when fi=1, r_ok=0, l_ok=0 → fault_out=1, conf_out=0.0.
+ * ====================================================================== */
+static void test_fault_injection_disables_sensors(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+    in.fi = 1U;   /* inject fault */
+
+    /* Run 3 cycles with fi=1 (within 30 ms = 3 cycles at 100 Hz) */
+    perception_step(&in, &out);
+    perception_step(&in, &out);
+    perception_step(&in, &out);
+
+    /* fault_flag must indicate both sensors faulted (chart_41 fault_out) */
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) != 0U,
+          "Fault injection: LiDAR fault flag set");
+    CHECK((out.fault_flag & AEB_FAULT_RADAR) != 0U,
+          "Fault injection: Radar fault flag set");
+
+    /* Confidence must be 0.0 when both sensors disabled (chart_41) */
+    CHECK(out.confidence == 0.0f,
+          "Fault injection: confidence = 0.0 (both sensors disabled)");
+}
+
+/* =========================================================================
+ * TEST 11 — Derived (confidence ordering)
+ * Confidence is higher with both sensors healthy than with only one.
+ * ====================================================================== */
+static void test_confidence_both_sensors_gt_one_sensor(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out_both;
+    perception_output_t out_one;
+    int i;
+
+    /* Both sensors OK — run 20 cycles to let P converge */
+    perception_init();
+    in = make_good_input();
+    for (i = 0; i < 20; i++) {
+        perception_step(&in, &out_both);
+    }
+
+    /* Only LiDAR OK (radar faulty distance) */
+    perception_init();
+    in = make_good_input();
+    in.radar_d = 999.0f;  /* force radar fault after 3 cycles */
+    for (i = 0; i < 20; i++) {
+        perception_step(&in, &out_one);
+    }
+
+    CHECK(out_both.confidence >= out_one.confidence,
+          "Confidence: both sensors >= one sensor");
+}
+
+/* =========================================================================
+ * TEST 12 — FR-PER-006
+ * Good data produces no fault flags at all.
+ * ====================================================================== */
+static void test_no_fault_on_good_data(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+
+    for (i = 0; i < 20; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK(out.fault_flag == 0U, "No faults on 20 cycles of good data");
+}
+
+/* =========================================================================
+ * TEST 13 — FR-PER-003
+ * Relative velocity clamped to [-MAX_REL_VEL, MAX_REL_VEL].
+ * ====================================================================== */
+static void test_output_clamp_rel_velocity(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    perception_init();
+    in = make_good_input();
+    /* Feed a safely high-but-valid velocity for many cycles */
+    in.radar_vr = 40.0f;
+    in.lidar_d  = 30.0f;
+
+    for (i = 0; i < 30; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK((out.v_rel >= -MAX_REL_VEL) &&
+          (out.v_rel <=  MAX_REL_VEL),
+          "Output: rel_velocity clamped within [-MAX_REL_VEL, MAX_REL_VEL]");
+}
+
+/* =========================================================================
+ * TEST 14 — FR-PER-002
+ * Ego velocity is passed through directly from input.
+ * ====================================================================== */
+static void test_ego_velocity_passthrough(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+    in.v_ego = 27.5f;
+
+    perception_step(&in, &out);
+
+    CHECK(out.v_ego == 27.5f, "Ego velocity: direct passthrough");
+}
+
+/* =========================================================================
+ * TEST 15 — FR-PER-006
+ * LiDAR ROC (rate-of-change) check: jump > DIST_ROC_LIMIT triggers counter.
+ * ====================================================================== */
+static void test_lidar_roc_triggers_counter(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+
+    /* Establish prev_d = 30 m (is_first cleared after this call) */
+    in.lidar_d = 30.0f;
+    perception_step(&in, &out);
+
+    /* Jump >10 m on 3 *consecutive* cycles so the ROC check fires each time.
+     * Each step must also differ from the previous by >DIST_ROC_LIMIT (10 m).
+     * Cycle 1: d=50, ROC |50-30|=20>10 → bad, ctr=1, prev_d=50
+     * Cycle 2: d=70, ROC |70-50|=20>10 → bad, ctr=2, prev_d=70
+     * Cycle 3: d=90, ROC |90-70|=20>10 → bad, ctr=3 → FAULT latched */
+    in.lidar_d = 50.0f;
+    perception_step(&in, &out);
+    in.lidar_d = 70.0f;
+    perception_step(&in, &out);
+    in.lidar_d = 90.0f;
+    perception_step(&in, &out);
+
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) != 0U,
+          "LiDAR: ROC > 10 m for 3 cycles latches fault");
+}
+
+/* =========================================================================
+ * TEST 16 — FR-PER-006, FR-PER-007
+ * Radar ROC: consecutive rate-of-change violations latch radar fault.
+ * Analogous to TEST 15 (LiDAR ROC) but for the radar detector.
+ * ====================================================================== */
+static void test_radar_roc_triggers_counter(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+
+    /* Establish prev_d = 30 m, prev_vr = 5 m/s (is_first cleared) */
+    perception_step(&in, &out);
+
+    /* 3 consecutive cycles with distance ROC > 10 m each.
+     * Velocity stays valid so only distance ROC triggers.
+     * Cycle 1: d=50, ROC |50-30|=20>10 → bad, ctr=1
+     * Cycle 2: d=70, ROC |70-50|=20>10 → bad, ctr=2
+     * Cycle 3: d=90, ROC |90-70|=20>10 → bad, ctr=3 → FAULT */
+    in.radar_d = 50.0f;
+    perception_step(&in, &out);
+    in.radar_d = 70.0f;
+    perception_step(&in, &out);
+    in.radar_d = 90.0f;
+    perception_step(&in, &out);
+
+    CHECK((out.fault_flag & AEB_FAULT_RADAR) != 0U,
+          "Radar: ROC > 10 m for 3 cycles latches fault");
+}
+
+/* =========================================================================
+ * TEST 17 — FR-PER-007
+ * perception_init() resets all static state: after a latched fault,
+ * calling init and feeding good data must produce fault_flag = 0.
+ * ====================================================================== */
+static void test_init_resets_state(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+    int i;
+
+    /* Phase 1: force LiDAR fault latch */
+    perception_init();
+    in = make_good_input();
+    in.lidar_d = 999.0f;
+    for (i = 0; i < (int)SENSOR_FAULT_CYCLES; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) != 0U,
+          "Init reset: fault latched before init");
+
+    /* Phase 2: reset and feed good data */
+    perception_init();
+    in = make_good_input();
+    for (i = 0; i < 5; i++) {
+        perception_step(&in, &out);
+    }
+    CHECK(out.fault_flag == 0U,
+          "Init reset: no faults after init + good data");
+}
+
+/* =========================================================================
+ * TEST 18 — FR-PER-007
+ * CAN timeout must not corrupt fault detector counters.
+ * Strategy: feed 1 bad LiDAR frame (ctr=1), then 1 CAN timeout (detectors
+ * skipped, ctr frozen at 1), then 1 more bad frame (ctr=2).
+ * If timeout had incremented the counter, ctr would reach 3 and fault
+ * would latch.  We assert no fault, proving timeout didn't corrupt state.
+ * ====================================================================== */
+static void test_can_timeout_preserves_counters(void)
+{
+    raw_sensor_input_t in;
+    perception_output_t out;
+
+    perception_init();
+    in = make_good_input();
+
+    /* Warm-up: establish prev_d with a good frame */
+    perception_step(&in, &out);
+
+    /* 1 bad LiDAR frame → ctr=1 */
+    in.lidar_d = 999.0f;
+    perception_step(&in, &out);
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) == 0U,
+          "CAN timeout preserves ctr: no fault after 1 bad frame");
+
+    /* CAN timeout: returns early, fault detectors NOT executed.
+     * Counter stays frozen at 1 (not incremented to 2). */
+    in.can_timeout = 1U;
+    perception_step(&in, &out);
+
+    /* Resume normal: 1 more bad frame (same value, no ROC issue).
+     * If timeout preserved state correctly: ctr goes from 1 → 2.
+     * If timeout had incremented: ctr would go from 2 → 3 = FAULT. */
+    in.can_timeout = 0U;
+    in.lidar_d = 999.0f;
+    perception_step(&in, &out);
+    CHECK((out.fault_flag & AEB_FAULT_LIDAR) == 0U,
+          "CAN timeout preserves ctr: counter not corrupted by timeout");
+}
+
+/* =========================================================================
+ * Main
+ * ====================================================================== */
+int main(void)
+{
+    printf("=== AEB Perception Unit Tests ===\n\n");
+
+    test_lidar_no_fault_before_latch();
+    test_lidar_fault_latches_at_cycle3();
+    test_lidar_counter_resets_on_good_frame();
+    test_radar_fault_latches_at_cycle3();
+    test_radar_no_fault_single_bad_vr();
+    test_can_timeout_sets_fault_flags();
+    test_kalman_convergence();
+    test_output_clamp_min_distance();
+    test_output_clamp_max_distance();
+    test_fault_injection_disables_sensors();
+    test_confidence_both_sensors_gt_one_sensor();
+    test_no_fault_on_good_data();
+    test_output_clamp_rel_velocity();
+    test_ego_velocity_passthrough();
+    test_lidar_roc_triggers_counter();
+    test_radar_roc_triggers_counter();
+    test_init_resets_state();
+    test_can_timeout_preserves_counters();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
+
+    return (g_fail == 0) ? 0 : 1;
+}


### PR DESCRIPTION
# Summary

* Replace Perception stub with full Kalman-fused sensor processing implementation
* LiDAR/Radar fault detection with rate-of-change validation and 3-cycle latch
* 2-state Kalman filter fusion with sequential LiDAR + Radar update
* CAN timeout handling, fault injection (V&V), and confidence scoring
* Add 18 unit tests (26 assertions, all passing)
* Enable MISRA C:2012 check on perception module in CI

# Related Issue
Closes #34 
Ref #39 

# Change Type
- [x] feat
- [ ] fix
- [ ] docs
- [x] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [x] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-PER-001: Fused distance output [0, 300] m via Kalman filter
- FR-PER-002: Ego velocity passthrough from CAN RX
- FR-PER-003: Fused relative velocity with clamping to [-MAX_REL_VEL, MAX_REL_VEL]
- FR-PER-006: Sensor fault detection (range check + rate-of-change) with 3-cycle latch
- FR-PER-007: CAN timeout detection with fault propagation and counter preservation
- FR-PER-008: Pass-through signals handled by the CAN Bus and Decision Logic modules

## Non-Functional Requirements
- NFR-COD-001: MISRA C:2012 compliance (zero violations)
- NFR-COD-002: Fixed-width types throughout (float32_t, uint8_t)
- NFR-SAF-005: Fault injection (fi=1) disables both sensors within 30 ms
- NFR-POR-002: Calibration parameters separated in aeb_config.h

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [x] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [x] CI passes
- [ ] Traceability updated
- [ ] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence
```bash
$ make build
=== Build OK: zero warnings ===

$ make test
=== Results: 14 run, 14 passed, 0 failed ===  (smoke)
=== Results: 26 passed, 0 failed ===  (perception)

$ make misra
Checking src/perception/aeb_perception.c ...
(only shared-header advisories — zero violations in aeb_perception.c)
```

# Reviewer Notes
- Kalman filter implements 2-state (distance, v_rel) prediction + sequential scalar LiDAR update + 2x2 Radar update
- Confidence scoring: both sensors OK = 1.0, radar-only = 0.7, lidar-only = 0.5, none = 0.0, scaled by covariance trace
- Fault detectors use SENSOR_FAULT_CYCLES (3) consecutive bad frames before latching — single glitch frames are tolerated
- CAN timeout path returns early, preserving fault detector counters (verified by test 18)
- SRC_MISRA in Makefile should be updated to include aeb_perception.c

# Risks / Open Points
None for this module.
