### PR TITLE
feat(execution): implement PI brake controller, alert mapping and ove…

### DIFF
--- a/include/aeb_alert.h
+++ b/include/aeb_alert.h
@@ -1,0 +1,91 @@
+/**
+ * @file    aeb_alert.h
+ * @brief   Alert mapping and driver override detection — public API.
+ * @module  Execution — Alert mapping and driver override detection
+ * @version 1.1
+ * @date    2026-04-10
+ *
+ * @details Maps FSM state to visual/audible alert outputs and detects
+ *          driver override conditions. Derived from Simulink chart_79
+ *          (Alert_Map) and chart_88 (Override_Det).
+ *
+ * @requirements FR-ALR-001 to FR-ALR-004, FR-DEC-006, FR-DEC-007
+ * @simulink     chart_79 (Alert_Map) — system_137.xml
+ *               chart_88 (Override_Det) — system_144.xml
+ */
+
+#ifndef AEB_ALERT_H
+#define AEB_ALERT_H
+
+#include "aeb_types.h"
+
+/* ── Alert enumerations (used by alert_map) ───────────────────────────── */
+
+/** @brief Alert type: visual, audible, or both. */
+typedef enum
+{
+    ALERT_NONE    = 0,   /**< No alert active.                          */
+    ALERT_VISUAL  = 1,   /**< Visual alert only (dashboard indicator).  */
+    ALERT_AUDIBLE = 2,   /**< Audible alert only (buzzer/beep).         */
+    ALERT_BOTH    = 3    /**< Visual + audible alert.                   */
+} alert_type_e;
+
+/**
+ * @brief Buzzer command pattern mapped from FSM state.
+ *
+ * @note Enum values do NOT follow severity order. The values are
+ *       assigned to match the Simulink Alert_Map (chart_79) output
+ *       encoding. The mapping to FSM states is:
+ *         SILENT(0)     -> OFF, STANDBY, POST_BRAKE
+ *         SINGLE(1)     -> WARNING
+ *         DOUBLE(2)     -> BRAKE_L1
+ *         CONTINUOUS(3) -> BRAKE_L3  (highest severity)
+ *         FAST_PULSE(4) -> BRAKE_L2
+ */
+typedef enum
+{
+    BUZZER_SILENT     = 0,   /**< No sound — OFF / STANDBY / POST_BRAKE. */
+    BUZZER_SINGLE     = 1,   /**< Single beep — WARNING state.           */
+    BUZZER_DOUBLE     = 2,   /**< Double beep — BRAKE_L1 state.          */
+    BUZZER_CONTINUOUS = 3,   /**< Continuous beep — BRAKE_L3 state.      */
+    BUZZER_FAST_PULSE = 4    /**< Fast pulse — BRAKE_L2 state.           */
+} buzzer_cmd_e;
+
+/**
+ * @brief Map FSM state to alert output signals.
+ *
+ * Mapping (from Simulink Alert_Map):
+ *   OFF / STANDBY    -> ALERT_NONE,  BUZZER_SILENT
+ *   WARNING          -> ALERT_BOTH,  BUZZER_SINGLE
+ *   BRAKE_L1         -> ALERT_BOTH,  BUZZER_DOUBLE
+ *   BRAKE_L2         -> ALERT_BOTH,  BUZZER_FAST_PULSE
+ *   BRAKE_L3         -> ALERT_BOTH,  BUZZER_CONTINUOUS
+ *   POST_BRAKE       -> ALERT_NONE,  BUZZER_SILENT
+ *
+ * @param[in]  fsm_state  Current FSM state (fsm_state_e value).
+ * @param[out] output     Pointer to alert output struct (must not be NULL).
+ *
+ * @requirement FR-ALR-001, FR-ALR-002, FR-ALR-004
+ */
+void alert_map(const uint8_t fsm_state, alert_output_t *output);
+
+/**
+ * @brief Detect driver override condition.
+ *
+ * Override is active when:
+ *   - brake_pedal != 0, OR
+ *   - |steering_angle| > STEERING_OVERRIDE_DEG (5 degrees)
+ *
+ * @note In POST_BRAKE state, only the accelerator pedal triggers override
+ *       (FR-FSM-006). This function handles the general case; the FSM
+ *       module applies the POST_BRAKE exception externally.
+ *
+ * @param[in] steering_angle  Steering wheel angle [degrees].
+ * @param[in] brake_pedal     Brake pedal status: 0=released, 1=pressed.
+ * @return    1 if override detected, 0 otherwise.
+ *
+ * @requirement FR-DEC-006, FR-DEC-007
+ */
+uint8_t override_detect(const float32_t steering_angle, const uint8_t brake_pedal);
+
+#endif /* AEB_ALERT_H */

--- a/include/aeb_pid.h
+++ b/include/aeb_pid.h
@@ -1,0 +1,53 @@
+/**
+ * @file    aeb_pid.h
+ * @brief   PI brake controller module — public API.
+ * @module  Execution — PID braking controller
+ * @version 1.1
+ * @date    2026-04-10
+ *
+ * @details Implements a PI controller with anti-windup and jerk limiting
+ *          to generate smooth brake commands based on FSM deceleration targets.
+ *          Derived from Simulink chart_96 (PID_Logic).
+ *
+ * @requirements FR-BRK-001 to FR-BRK-007
+ * @simulink     chart_96 (PID_Logic) — system_150.xml
+ */
+
+#ifndef AEB_PID_H
+#define AEB_PID_H
+
+#include "aeb_types.h"
+
+/**
+ * @brief Initialise PID controller internal state.
+ *
+ * Resets integrator accumulator, previous brake output, and all flags.
+ * Must be called once at system startup before the first cycle.
+ *
+ * @requirement FR-BRK-002 (controller initialisation)
+ */
+void pid_init(void);
+
+/**
+ * @brief Execute one PI brake controller step.
+ *
+ * Computes brake command [0-100%] using PI control law with:
+ *   - Proportional + integral action (Kp=10.0, Ki=0.05)
+ *   - Anti-windup clamping on integral term [0, 50%]
+ *   - Jerk limiting: |delta_output| <= MAX_JERK * (100/DECEL_L3) * dt
+ *   - Output clamped to [0, 100%]
+ *   - Conversion to brake pressure: bar = pct / 10
+ *   - Controller reset when not in braking states
+ *
+ * @param[in]  decel_target  Target deceleration from FSM module [m/s^2].
+ * @param[in]  a_ego         Current ego vehicle deceleration [m/s^2].
+ * @param[in]  fsm_state     Current FSM state (fsm_state_e value).
+ * @param[out] output        Pointer to PID output struct (must not be NULL).
+ *
+ * @requirement FR-BRK-001, FR-BRK-002, FR-BRK-003, FR-BRK-004,
+ *              FR-BRK-005, FR-BRK-006, FR-BRK-007
+ */
+void pid_brake_step(const float32_t decel_target, const float32_t a_ego,
+                    const uint8_t fsm_state, pid_output_t *output);
+
+#endif /* AEB_PID_H */

--- a/src/execution/aeb_alert.c
+++ b/src/execution/aeb_alert.c
@@ -1,20 +1,162 @@
 /**
- * @file  aeb_alert.c
- * @brief Alert Mapping — STUB (Task C placeholder).
+ * @file    aeb_alert.c
+ * @brief   Alert mapping and driver override detection — full implementation.
+ * @module  Execution — Alert mapping and driver override detection
+ * @version 1.1
+ * @date    2026-04-10
  *
- * This file will be replaced by Jessica's implementation.
+ * @details Implements two functions:
+ *
+ *          alert_map():  Maps FSM state to alert type and buzzer pattern.
+ *          Derived from Simulink chart_79 (Alert_Map) — system_137.xml.
+ *          Data flow: FSM.fsm_state -> Alert_Logic -> alert_type,
+ *          alert_active, buzzer_cmd.
+ *
+ *          override_detect():  Detects driver override via brake pedal
+ *          or steering input. Derived from Simulink chart_88
+ *          (Override_Det) — system_144.xml.
+ *          Data flow: steering_angle, brake_pedal -> Driver_Override
+ *          -> override_active (fed to FSM module input).
+ *
+ * @requirements FR-ALR-001 to FR-ALR-004, FR-DEC-006, FR-DEC-007
+ *
+ * @req FR-ALR-001  Visual alert upon WARNING entry, within 1 cycle.
+ * @req FR-ALR-002  Audible alert upon WARNING entry, within 1 cycle.
+ * @req FR-ALR-003  Alert precedes braking by >= 800 ms (enforced by FSM module).
+ * @req FR-ALR-004  Alert ceases when returning to STANDBY or driver override.
+ * @req FR-DEC-006  Override on brake pedal press.
+ * @req FR-DEC-007  Override on steering angle > 5 degrees.
+ *
+ * @standard MISRA C:2012 compliant.
  */
 
-#include "aeb_types.h"
+#include "aeb_alert.h"
+#include "aeb_config.h"
 
-void alert_map(const uint8_t fsm_state, alert_output_t *out)
+/* ========================================================================= */
+/*  Private helper — absolute value for float32                              */
+/* ========================================================================= */
+
+/**
+ * @brief Compute absolute value of a float32.
+ * @param[in] val  Input value.
+ * @return Absolute value.
+ */
+static float32_t abs_f32(const float32_t val)
 {
-    (void)fsm_state;
+    float32_t result = val;
 
-    if (out != (void *)0)
+    if (result < 0.0F)
     {
-        out->alert_type   = 0U;
-        out->alert_active = 0U;
-        out->buzzer_cmd   = 0U;
+        result = -result;
     }
+
+    return result;
+}
+
+/* ========================================================================= */
+/*  Public API                                                               */
+/* ========================================================================= */
+
+void alert_map(const uint8_t fsm_state, alert_output_t *output)
+{
+    /* Defensive NULL check — safety-critical code (MISRA C:2012) */
+    if (output == (void *)0)
+    {
+        /* Cannot write output; abort without side effects */
+    }
+    else
+    {
+        /*
+         * Alert mapping table — derived from Simulink Alert_Map (chart_79).
+         *
+         * The mapping is a pure combinational function: no internal state,
+         * no memory between cycles. The FSM module guarantees that WARNING
+         * is held for >= 800 ms before any braking state (FR-ALR-003), so
+         * this function does not need to enforce timing.
+         *
+         * State          | alert_type | buzzer_cmd    | alert_active
+         * ---------------|------------|---------------|-------------
+         * OFF (0)        | NONE (0)   | SILENT (0)    | 0
+         * STANDBY (1)    | NONE (0)   | SILENT (0)    | 0
+         * WARNING (2)    | BOTH (3)   | SINGLE (1)    | 1
+         * BRAKE_L1 (3)   | BOTH (3)   | DOUBLE (2)    | 1
+         * BRAKE_L2 (4)   | BOTH (3)   | FAST_PULSE (4)| 1
+         * BRAKE_L3 (5)   | BOTH (3)   | CONTINUOUS (3)| 1
+         * POST_BRAKE (6) | NONE (0)   | SILENT (0)    | 0
+         */
+
+        switch (fsm_state)
+        {
+            case (uint8_t)FSM_WARNING:
+                output->alert_type   = (uint8_t)ALERT_BOTH;
+                output->alert_active = 1U;
+                output->buzzer_cmd   = (uint8_t)BUZZER_SINGLE;
+                break;
+
+            case (uint8_t)FSM_BRAKE_L1:
+                output->alert_type   = (uint8_t)ALERT_BOTH;
+                output->alert_active = 1U;
+                output->buzzer_cmd   = (uint8_t)BUZZER_DOUBLE;
+                break;
+
+            case (uint8_t)FSM_BRAKE_L2:
+                output->alert_type   = (uint8_t)ALERT_BOTH;
+                output->alert_active = 1U;
+                output->buzzer_cmd   = (uint8_t)BUZZER_FAST_PULSE;
+                break;
+
+            case (uint8_t)FSM_BRAKE_L3:
+                output->alert_type   = (uint8_t)ALERT_BOTH;
+                output->alert_active = 1U;
+                output->buzzer_cmd   = (uint8_t)BUZZER_CONTINUOUS;
+                break;
+
+            case (uint8_t)FSM_OFF:        /* fall-through */
+            case (uint8_t)FSM_STANDBY:    /* fall-through */
+            case (uint8_t)FSM_POST_BRAKE: /* fall-through */
+            default:
+                output->alert_type   = (uint8_t)ALERT_NONE;
+                output->alert_active = 0U;
+                output->buzzer_cmd   = (uint8_t)BUZZER_SILENT;
+                break;
+        }
+    }
+}
+
+uint8_t override_detect(const float32_t steering_angle, const uint8_t brake_pedal)
+{
+    /*
+     * Driver override detection — derived from Simulink Override_Det (chart_88).
+     *
+     * The function is pure combinational: returns 1 if the driver is
+     * actively intervening via brake pedal or evasive steering.
+     *
+     * Conditions (OR logic):
+     *   - brake_pedal != 0                          (FR-DEC-006)
+     *   - |steering_angle| > STEERING_OVERRIDE_DEG  (FR-DEC-007, 5 degrees)
+     *
+     * Note: In POST_BRAKE state, only the accelerator pedal triggers
+     * override (FR-FSM-006). That exception is handled by the FSM module,
+     * which ignores brake_pedal and steering_angle override signals when
+     * in POST_BRAKE. This function always reports the general-case
+     * override condition.
+     */
+
+    uint8_t result = 0U;
+
+    if (brake_pedal != 0U)
+    {
+        result = 1U;
+    }
+    else if (abs_f32(steering_angle) > STEERING_OVERRIDE_DEG)
+    {
+        result = 1U;
+    }
+    else
+    {
+        result = 0U;
+    }
+
+    return result;
 }

--- a/src/execution/aeb_pid.c
+++ b/src/execution/aeb_pid.c
@@ -1,29 +1,188 @@
 /**
- * @file  aeb_pid.c
- * @brief PID Brake Controller — STUB (Task C placeholder).
+ * @file    aeb_pid.c
+ * @brief   PI brake controller — full implementation.
+ * @module  Execution — PID braking controller
+ * @version 1.1
+ * @date    2026-04-10
  *
- * This file will be replaced by Jessica's implementation.
+ * @details Implements a PI controller with anti-windup clamping and jerk
+ *          limiting, generating a brake command in [0, 100]% and a brake
+ *          pressure in [0, 10] bar. The algorithm is derived from the
+ *          Simulink chart_96 (PID_Logic) in AEB_Integration.slx.
+ *
+ *          Data flow in Simulink (system_107.xml):
+ *            FSM.decel_target -> PID_Brake.in:1
+ *            a_ego (inport 4) -> PID_Brake.in:2
+ *            FSM.fsm_state   -> PID_Brake.in:3
+ *            PID_Brake.out:1 -> brake_pct
+ *            PID_Brake.out:2 -> brake_bar
+ *
+ * @requirements FR-BRK-001 to FR-BRK-007
+ *
+ * @req FR-BRK-001  Progressive deceleration, no jumps > 2 m/s^2 between cycles.
+ * @req FR-BRK-002  PI controller with anti-windup, error < 0.5 m/s^2 in 500 ms.
+ * @req FR-BRK-003  Capable of generating >= 5.0 m/s^2 braking demand.
+ * @req FR-BRK-004  Jerk limited to |jerk| <= 10 m/s^3.
+ * @req FR-BRK-005  Maintain braking >= 2 s after full stop (POST_BRAKE).
+ * @req FR-BRK-006  Release brake within 1 cycle after accelerator in POST_BRAKE.
+ * @req FR-BRK-007  Output clamped to [0, 100]%.
+ *
+ * @standard MISRA C:2012 compliant.
  */
 
-#include "aeb_types.h"
+#include "aeb_pid.h"
+#include "aeb_config.h"
+
+/* ========================================================================= */
+/*  Module-internal persistent state                                         */
+/* ========================================================================= */
+
+/** @brief Integral accumulator for the PI controller [%]. */
+static float32_t s_integral = 0.0F;
+
+/** @brief Previous cycle brake output for jerk limiting [%]. */
+static float32_t s_prev_brake_pct = 0.0F;
+
+/* ========================================================================= */
+/*  Private helper — clamp a value to [lo, hi]                               */
+/* ========================================================================= */
+
+/**
+ * @brief Clamp a float32 value to a specified range.
+ * @param[in] val  Value to clamp.
+ * @param[in] lo   Lower bound.
+ * @param[in] hi   Upper bound.
+ * @return Clamped value.
+ */
+static float32_t clamp_f32(const float32_t val, const float32_t lo, const float32_t hi)
+{
+    float32_t result = val;
+
+    if (result < lo)
+    {
+        result = lo;
+    }
+    else if (result > hi)
+    {
+        result = hi;
+    }
+    else
+    {
+        /* value already within range — no action */
+    }
+
+    return result;
+}
+
+/* ========================================================================= */
+/*  Public API                                                               */
+/* ========================================================================= */
 
 void pid_init(void)
 {
-    /* STUB — Task C (Jessica) */
+    s_integral       = 0.0F;
+    s_prev_brake_pct = 0.0F;
 }
 
-void pid_brake_step(const float32_t decel_target,
-                    const float32_t a_ego,
-                    const uint8_t   fsm_state,
-                    pid_output_t *out)
+void pid_brake_step(const float32_t decel_target, const float32_t a_ego,
+                    const uint8_t fsm_state, pid_output_t *output)
 {
-    (void)decel_target;
-    (void)a_ego;
-    (void)fsm_state;
+    float32_t error       = 0.0F;
+    float32_t p_term      = 0.0F;
+    float32_t raw_output  = 0.0F;
+    float32_t max_delta   = 0.0F;
+    float32_t delta       = 0.0F;
+    float32_t brake_pct   = 0.0F;
 
-    if (out != (void *)0)
+    /* Defensive NULL check — safety-critical code (MISRA C:2012) */
+    if (output == (void *)0)
     {
-        out->brake_pct = 0.0F;
-        out->brake_bar = 0.0F;
+        /* Cannot write output; abort without side effects */
+    }
+    else
+    {
+        /* ------------------------------------------------------------------
+         * Guard: controller is only active in braking states (L1, L2, L3)
+         * and POST_BRAKE. In all other states, reset and output zero.
+         *
+         * FSM_BRAKE_L1 = 3, FSM_BRAKE_L2 = 4, FSM_BRAKE_L3 = 5,
+         * FSM_POST_BRAKE = 6
+         *
+         * Rationale: decel_target is zero outside braking states, but we
+         * also reset the integrator to avoid wind-up carry-over.
+         * FR-BRK-006 is handled by the FSM module: when the driver presses
+         * the accelerator in POST_BRAKE, the FSM transitions to STANDBY
+         * and decel_target becomes 0, so the controller resets here.
+         *
+         * MISRA C:2012 Rule 15.5: single exit point — no early return.
+         * ---------------------------------------------------------------- */
+        if ((fsm_state < (uint8_t)FSM_BRAKE_L1) || (decel_target <= 0.0F))
+        {
+            /* Reset controller state */
+            s_integral       = 0.0F;
+            s_prev_brake_pct = 0.0F;
+        }
+        else
+        {
+            /* ----------------------------------------------------------
+             * PI control law
+             *
+             * error = decel_target - a_ego
+             *   (positive error means we need more braking)
+             *
+             * integral += Ki * error * dt
+             *   (anti-windup: integral clamped to [0, PID_INTEG_MAX])
+             *
+             * output = Kp * error + integral
+             * ---------------------------------------------------------- */
+            error = decel_target - a_ego;
+
+            /* Proportional term */
+            p_term = PID_KP * error;
+
+            /* Integral term with anti-windup (FR-BRK-002) */
+            s_integral = s_integral + (PID_KI * error * AEB_DT);
+            s_integral = clamp_f32(s_integral, 0.0F, PID_INTEG_MAX);
+
+            /* Combined PI output */
+            raw_output = p_term + s_integral;
+
+            /* ----------------------------------------------------------
+             * Jerk limiting (FR-BRK-004)
+             *
+             * Maximum allowed change per cycle:
+             *   max_delta = MAX_JERK * (100 / DECEL_L3) * AEB_DT
+             *            = 10 * (100/6) * 0.01 = 1.667 %/cycle
+             *
+             * Also satisfies FR-BRK-001 (no jumps > 2 m/s^2).
+             * ---------------------------------------------------------- */
+            max_delta = MAX_JERK * (BRAKE_OUT_MAX / DECEL_L3) * AEB_DT;
+
+            /* Clamp output to valid range first */
+            brake_pct = clamp_f32(raw_output, BRAKE_OUT_MIN, BRAKE_OUT_MAX);
+
+            /* Apply jerk limit relative to previous output */
+            delta = brake_pct - s_prev_brake_pct;
+            delta = clamp_f32(delta, -max_delta, max_delta);
+            brake_pct = s_prev_brake_pct + delta;
+
+            /* Final clamp after jerk limiting (FR-BRK-007) */
+            brake_pct = clamp_f32(brake_pct, BRAKE_OUT_MIN, BRAKE_OUT_MAX);
+
+            /* Store for next cycle */
+            s_prev_brake_pct = brake_pct;
+        }
+
+        /* --------------------------------------------------------------
+         * Output assignment — single exit point (MISRA C:2012 Rule 15.5)
+         *
+         * brake_pct: [0, 100] %  (FR-BRK-007)
+         * brake_bar: [0, 10] bar (linear mapping: bar = pct / 10)
+         *
+         * When guard resets the controller, brake_pct remains 0.0F
+         * (initialised at declaration), producing zero output.
+         * -------------------------------------------------------------- */
+        output->brake_pct = brake_pct;
+        output->brake_bar = brake_pct / 10.0F;
     }
 }

--- a/tests/test_alert.c
+++ b/tests/test_alert.c
@@ -1,0 +1,290 @@
+/**
+ * @file    test_alert.c
+ * @brief   Unit tests for the Execution alert module (aeb_alert).
+ * @module  Execution — Alert mapping and override detection tests
+ * @version 1.1
+ * @date    2026-04-10
+ *
+ * @details Tests alert mapping and override detection against
+ *          FR-ALR-001 to FR-ALR-004, FR-DEC-006, FR-DEC-007.
+ *
+ * @requirements FR-ALR-001 to FR-ALR-004, FR-DEC-006, FR-DEC-007
+ */
+
+#include <stdio.h>
+#include "aeb_alert.h"
+#include "aeb_config.h"
+
+/* ========================================================================= */
+/*  Minimal test framework                                                   */
+/* ========================================================================= */
+
+static int g_test_count  = 0;
+static int g_pass_count  = 0;
+static int g_fail_count  = 0;
+
+#define TEST_ASSERT(cond, msg)                                              \
+    do {                                                                     \
+        g_test_count++;                                                      \
+        if (cond) {                                                          \
+            g_pass_count++;                                                  \
+            printf("  PASS: %s\n", (msg));                                   \
+        } else {                                                             \
+            g_fail_count++;                                                  \
+            printf("  FAIL: %s [%s:%d]\n", (msg), __FILE__, __LINE__);       \
+        }                                                                    \
+    } while (0)
+
+#define TEST_ASSERT_EQ(val, expected, msg)                                  \
+    TEST_ASSERT((val) == (expected), (msg))
+
+/* ========================================================================= */
+/*  Alert mapping tests                                                      */
+/* ========================================================================= */
+
+/**
+ * @brief FR-ALR-004: OFF state — no alert.
+ */
+static void test_alert_off(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: OFF state\n");
+    alert_map((uint8_t)FSM_OFF, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_NONE,
+        "alert_type == NONE in OFF");
+    TEST_ASSERT_EQ(out.alert_active, 0U,
+        "alert_active == 0 in OFF");
+    TEST_ASSERT_EQ(out.buzzer_cmd, (uint8_t)BUZZER_SILENT,
+        "buzzer == SILENT in OFF");
+}
+
+/**
+ * @brief FR-ALR-004: STANDBY state — no alert.
+ */
+static void test_alert_standby(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: STANDBY state\n");
+    alert_map((uint8_t)FSM_STANDBY, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_NONE,
+        "alert_type == NONE in STANDBY");
+    TEST_ASSERT_EQ(out.alert_active, 0U,
+        "alert_active == 0 in STANDBY");
+}
+
+/**
+ * @brief FR-ALR-001, FR-ALR-002: WARNING — visual + audible alert.
+ */
+static void test_alert_warning(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: WARNING state\n");
+    alert_map((uint8_t)FSM_WARNING, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_BOTH,
+        "alert_type == BOTH in WARNING (visual + audible)");
+    TEST_ASSERT_EQ(out.alert_active, 1U,
+        "alert_active == 1 in WARNING");
+    TEST_ASSERT_EQ(out.buzzer_cmd, (uint8_t)BUZZER_SINGLE,
+        "buzzer == SINGLE in WARNING");
+}
+
+/**
+ * @brief BRAKE_L1 — both alerts, double beep.
+ */
+static void test_alert_brake_l1(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: BRAKE_L1 state\n");
+    alert_map((uint8_t)FSM_BRAKE_L1, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_BOTH,
+        "alert_type == BOTH in BRAKE_L1");
+    TEST_ASSERT_EQ(out.alert_active, 1U,
+        "alert_active == 1 in BRAKE_L1");
+    TEST_ASSERT_EQ(out.buzzer_cmd, (uint8_t)BUZZER_DOUBLE,
+        "buzzer == DOUBLE in BRAKE_L1");
+}
+
+/**
+ * @brief BRAKE_L2 — both alerts, fast pulse.
+ */
+static void test_alert_brake_l2(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: BRAKE_L2 state\n");
+    alert_map((uint8_t)FSM_BRAKE_L2, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_BOTH,
+        "alert_type == BOTH in BRAKE_L2");
+    TEST_ASSERT_EQ(out.buzzer_cmd, (uint8_t)BUZZER_FAST_PULSE,
+        "buzzer == FAST_PULSE in BRAKE_L2");
+}
+
+/**
+ * @brief BRAKE_L3 — both alerts, continuous beep.
+ */
+static void test_alert_brake_l3(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: BRAKE_L3 state\n");
+    alert_map((uint8_t)FSM_BRAKE_L3, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_BOTH,
+        "alert_type == BOTH in BRAKE_L3");
+    TEST_ASSERT_EQ(out.buzzer_cmd, (uint8_t)BUZZER_CONTINUOUS,
+        "buzzer == CONTINUOUS in BRAKE_L3");
+}
+
+/**
+ * @brief FR-ALR-004: POST_BRAKE — no alert.
+ */
+static void test_alert_post_brake(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: POST_BRAKE state\n");
+    alert_map((uint8_t)FSM_POST_BRAKE, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_NONE,
+        "alert_type == NONE in POST_BRAKE");
+    TEST_ASSERT_EQ(out.alert_active, 0U,
+        "alert_active == 0 in POST_BRAKE");
+    TEST_ASSERT_EQ(out.buzzer_cmd, (uint8_t)BUZZER_SILENT,
+        "buzzer == SILENT in POST_BRAKE");
+}
+
+/**
+ * @brief Invalid state — defaults to no alert (MISRA default case).
+ */
+static void test_alert_invalid_state(void)
+{
+    alert_output_t out = {0U, 0U, 0U};
+
+    printf("\n[TEST] alert: invalid state (99)\n");
+    alert_map(99U, &out);
+
+    TEST_ASSERT_EQ(out.alert_type, (uint8_t)ALERT_NONE,
+        "alert_type == NONE for invalid state");
+    TEST_ASSERT_EQ(out.alert_active, 0U,
+        "alert_active == 0 for invalid state");
+}
+
+/* ========================================================================= */
+/*  Override detection tests                                                 */
+/* ========================================================================= */
+
+/**
+ * @brief No override: no pedal, no steering.
+ */
+static void test_override_none(void)
+{
+    printf("\n[TEST] override: no inputs\n");
+    uint8_t result = override_detect(0.0F, 0U);
+    TEST_ASSERT_EQ(result, 0U, "no override when all inputs inactive");
+}
+
+/**
+ * @brief FR-DEC-006: Brake pedal override.
+ */
+static void test_override_brake_pedal(void)
+{
+    printf("\n[TEST] override: brake pedal\n");
+    uint8_t result = override_detect(0.0F, 1U);
+    TEST_ASSERT_EQ(result, 1U, "override active on brake pedal");
+}
+
+/**
+ * @brief FR-DEC-007: Steering override > 5 degrees positive.
+ */
+static void test_override_steering_positive(void)
+{
+    printf("\n[TEST] override: steering > +5 deg\n");
+    uint8_t result = override_detect(6.0F, 0U);
+    TEST_ASSERT_EQ(result, 1U, "override active at +6 degrees");
+}
+
+/**
+ * @brief FR-DEC-007: Steering override > 5 degrees negative.
+ */
+static void test_override_steering_negative(void)
+{
+    printf("\n[TEST] override: steering < -5 deg\n");
+    uint8_t result = override_detect(-7.0F, 0U);
+    TEST_ASSERT_EQ(result, 1U, "override active at -7 degrees");
+}
+
+/**
+ * @brief No override at exactly 5 degrees (boundary — not exceeded).
+ */
+static void test_override_steering_boundary(void)
+{
+    printf("\n[TEST] override: steering exactly 5 deg (boundary)\n");
+    uint8_t result = override_detect(5.0F, 0U);
+    TEST_ASSERT_EQ(result, 0U, "no override at exactly 5 degrees (not >5)");
+}
+
+/**
+ * @brief No override at 4.9 degrees.
+ */
+static void test_override_steering_below(void)
+{
+    printf("\n[TEST] override: steering 4.9 deg (below threshold)\n");
+    uint8_t result = override_detect(4.9F, 0U);
+    TEST_ASSERT_EQ(result, 0U, "no override at 4.9 degrees");
+}
+
+/**
+ * @brief Both brake and steering active — still override.
+ */
+static void test_override_both(void)
+{
+    printf("\n[TEST] override: both brake + steering\n");
+    uint8_t result = override_detect(10.0F, 1U);
+    TEST_ASSERT_EQ(result, 1U, "override active with both inputs");
+}
+
+/* ========================================================================= */
+/*  Main                                                                     */
+/* ========================================================================= */
+
+int main(void)
+{
+    printf("========================================\n");
+    printf("  AEB Alert & Override — Unit Tests\n");
+    printf("========================================\n");
+
+    /* Alert mapping */
+    test_alert_off();
+    test_alert_standby();
+    test_alert_warning();
+    test_alert_brake_l1();
+    test_alert_brake_l2();
+    test_alert_brake_l3();
+    test_alert_post_brake();
+    test_alert_invalid_state();
+
+    /* Override detection */
+    test_override_none();
+    test_override_brake_pedal();
+    test_override_steering_positive();
+    test_override_steering_negative();
+    test_override_steering_boundary();
+    test_override_steering_below();
+    test_override_both();
+
+    printf("\n========================================\n");
+    printf("  Results: %d/%d passed, %d failed\n",
+           g_pass_count, g_test_count, g_fail_count);
+    printf("========================================\n");
+
+    return (g_fail_count > 0) ? 1 : 0;
+}

--- a/tests/test_pid.c
+++ b/tests/test_pid.c
@@ -1,0 +1,394 @@
+/**
+ * @file    test_pid.c
+ * @brief   Unit tests for the Execution PID module (aeb_pid).
+ * @module  Execution — PID braking controller tests
+ * @version 1.1
+ * @date    2026-04-10
+ *
+ * @details Tests the PI brake controller against all FR-BRK requirements.
+ *          Uses a minimal test framework compatible with both native GCC
+ *          and Zephyr ztest.
+ *
+ * @requirements FR-BRK-001 to FR-BRK-007
+ */
+
+#include <stdio.h>
+#include <math.h>
+#include "aeb_pid.h"
+#include "aeb_config.h"
+
+/* ========================================================================= */
+/*  Minimal test framework                                                   */
+/* ========================================================================= */
+
+static int g_test_count  = 0;
+static int g_pass_count  = 0;
+static int g_fail_count  = 0;
+
+#define TEST_ASSERT(cond, msg)                                              \
+    do {                                                                     \
+        g_test_count++;                                                      \
+        if (cond) {                                                          \
+            g_pass_count++;                                                  \
+            printf("  PASS: %s\n", (msg));                                   \
+        } else {                                                             \
+            g_fail_count++;                                                  \
+            printf("  FAIL: %s [%s:%d]\n", (msg), __FILE__, __LINE__);       \
+        }                                                                    \
+    } while (0)
+
+#define TEST_ASSERT_FLOAT_LT(val, limit, msg)                               \
+    TEST_ASSERT((val) < (limit), (msg))
+
+#define TEST_ASSERT_FLOAT_GE(val, limit, msg)                               \
+    TEST_ASSERT((val) >= (limit), (msg))
+
+#define TEST_ASSERT_FLOAT_EQ(val, expected, tol, msg)                       \
+    TEST_ASSERT(fabs((double)(val) - (double)(expected)) < (double)(tol), (msg))
+
+/* ========================================================================= */
+/*  Test cases                                                               */
+/* ========================================================================= */
+
+/**
+ * @brief FR-BRK-007: Output shall be zero when not in braking state.
+ */
+static void test_pid_no_braking_in_standby(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: no braking in STANDBY\n");
+    pid_init();
+    pid_brake_step(0.0F, 0.0F, (uint8_t)FSM_STANDBY, &out);
+
+    TEST_ASSERT_FLOAT_EQ(out.brake_pct, 0.0F, 0.001F,
+        "brake_pct == 0 in STANDBY");
+    TEST_ASSERT_FLOAT_EQ(out.brake_bar, 0.0F, 0.001F,
+        "brake_bar == 0 in STANDBY");
+}
+
+/**
+ * @brief FR-BRK-007: Output zero in OFF state.
+ */
+static void test_pid_no_braking_in_off(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: no braking in OFF\n");
+    pid_init();
+    pid_brake_step(2.0F, 0.0F, (uint8_t)FSM_OFF, &out);
+
+    TEST_ASSERT_FLOAT_EQ(out.brake_pct, 0.0F, 0.001F,
+        "brake_pct == 0 in OFF even with decel_target > 0");
+}
+
+/**
+ * @brief FR-BRK-007: Output zero in WARNING state (alert only, no braking).
+ */
+static void test_pid_no_braking_in_warning(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: no braking in WARNING\n");
+    pid_init();
+    pid_brake_step(2.0F, 0.0F, (uint8_t)FSM_WARNING, &out);
+
+    TEST_ASSERT_FLOAT_EQ(out.brake_pct, 0.0F, 0.001F,
+        "brake_pct == 0 in WARNING");
+}
+
+/**
+ * @brief FR-BRK-002: PI controller produces positive output in BRAKE_L1.
+ */
+static void test_pid_brake_l1_produces_output(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: BRAKE_L1 produces positive output\n");
+    pid_init();
+
+    /* Simulate several cycles to build up output */
+    uint8_t i = 0U;
+    for (i = 0U; i < 50U; i++)
+    {
+        pid_brake_step(DECEL_L1, 0.0F, (uint8_t)FSM_BRAKE_L1, &out);
+    }
+
+    TEST_ASSERT(out.brake_pct > 0.0F,
+        "brake_pct > 0 after 50 cycles in BRAKE_L1");
+    TEST_ASSERT_FLOAT_GE(out.brake_bar, 0.0F,
+        "brake_bar >= 0");
+}
+
+/**
+ * @brief FR-BRK-007: Output always clamped to [0, 100]%.
+ */
+static void test_pid_output_clamping(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: output clamping [0, 100]%%\n");
+    pid_init();
+
+    /* Drive controller hard with max deceleration for many cycles */
+    uint16_t i = 0U;
+    for (i = 0U; i < 500U; i++)
+    {
+        pid_brake_step(DECEL_L3, 0.0F, (uint8_t)FSM_BRAKE_L3, &out);
+    }
+
+    TEST_ASSERT(out.brake_pct <= BRAKE_OUT_MAX,
+        "brake_pct <= 100% after saturation");
+    TEST_ASSERT(out.brake_pct >= BRAKE_OUT_MIN,
+        "brake_pct >= 0%");
+    TEST_ASSERT(out.brake_bar <= 10.0F,
+        "brake_bar <= 10 bar");
+}
+
+/**
+ * @brief FR-BRK-004: Jerk limiting — output change per cycle bounded.
+ */
+static void test_pid_jerk_limiting(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+    float32_t prev_pct = 0.0F;
+    float32_t max_delta = MAX_JERK * (BRAKE_OUT_MAX / DECEL_L3) * AEB_DT;
+    uint8_t jerk_ok = 1U;
+
+    printf("\n[TEST] pid: jerk limiting <= %.3f %%/cycle\n", (double)max_delta);
+    pid_init();
+
+    /* Step from zero to max braking and check each transition */
+    uint8_t i = 0U;
+    for (i = 0U; i < 100U; i++)
+    {
+        pid_brake_step(DECEL_L3, 0.0F, (uint8_t)FSM_BRAKE_L3, &out);
+        float32_t delta = out.brake_pct - prev_pct;
+        if (delta < 0.0F) { delta = -delta; }
+
+        /* Allow small floating-point tolerance */
+        if (delta > (max_delta + 0.01F))
+        {
+            printf("    Jerk violation at cycle %u: delta=%.4f, max=%.4f\n",
+                   (unsigned)i, (double)delta, (double)max_delta);
+            jerk_ok = 0U;
+        }
+        prev_pct = out.brake_pct;
+    }
+
+    TEST_ASSERT(jerk_ok == 1U,
+        "no jerk violations across 100 cycles");
+}
+
+/**
+ * @brief FR-BRK-002: PI controller converges — error decreases over time.
+ */
+static void test_pid_steady_state_convergence(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+    float32_t a_ego = 0.0F;
+    float32_t a_cmd = 0.0F;
+    float32_t tau = 0.1F; /* 100 ms actuator time constant */
+
+    printf("\n[TEST] pid: steady-state convergence\n");
+    pid_init();
+
+    /* Simulate 300 cycles (3 s) with first-order plant */
+    uint16_t i = 0U;
+    for (i = 0U; i < 300U; i++)
+    {
+        pid_brake_step(DECEL_L3, a_ego, (uint8_t)FSM_BRAKE_L3, &out);
+        a_cmd = out.brake_pct * DECEL_L3 / BRAKE_OUT_MAX;
+        a_ego = a_ego + (AEB_DT / tau) * (a_cmd - a_ego);
+    }
+
+    /* Verify the controller is producing positive output */
+    TEST_ASSERT(out.brake_pct > 30.0F,
+        "PI output > 30% (controller actively braking)");
+
+    /* Verify the output is stable (not oscillating) */
+    float32_t pct_before = out.brake_pct;
+    for (i = 0U; i < 50U; i++)
+    {
+        pid_brake_step(DECEL_L3, a_ego, (uint8_t)FSM_BRAKE_L3, &out);
+        a_cmd = out.brake_pct * DECEL_L3 / BRAKE_OUT_MAX;
+        a_ego = a_ego + (AEB_DT / tau) * (a_cmd - a_ego);
+    }
+    float32_t drift = out.brake_pct - pct_before;
+    if (drift < 0.0F) { drift = -drift; }
+
+    TEST_ASSERT(drift < 2.0F,
+        "output drift < 2% over 50 cycles (stable convergence)");
+}
+
+/**
+ * @brief FR-BRK-003: System capable of generating >= 5.0 m/s^2.
+ */
+static void test_pid_max_braking_capability(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: max braking capability >= 5.0 m/s^2\n");
+    pid_init();
+
+    /* Open-loop: integral accumulates until output exceeds 83.33% */
+    uint16_t i = 0U;
+    for (i = 0U; i < 10000U; i++)
+    {
+        pid_brake_step(DECEL_L3, 0.0F, (uint8_t)FSM_BRAKE_L3, &out);
+    }
+
+    /* Map brake_pct to deceleration */
+    float32_t achieved_decel = out.brake_pct * DECEL_L3 / BRAKE_OUT_MAX;
+
+    TEST_ASSERT_FLOAT_GE(achieved_decel, 5.0F,
+        "achievable deceleration >= 5.0 m/s^2");
+}
+
+/**
+ * @brief FR-BRK-005 / FR-BRK-006: POST_BRAKE maintains braking.
+ *
+ * Fix #5: replaced dead variable brake_before_post with a meaningful
+ * assertion verifying that brake output does not drop significantly
+ * when transitioning from BRAKE_L3 to POST_BRAKE.
+ */
+static void test_pid_post_brake_hold(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: POST_BRAKE maintains braking\n");
+    pid_init();
+
+    /* Build up brake command in BRAKE_L3 */
+    uint16_t i = 0U;
+    for (i = 0U; i < 200U; i++)
+    {
+        pid_brake_step(DECEL_L3, 0.0F, (uint8_t)FSM_BRAKE_L3, &out);
+    }
+
+    float32_t pct_before_post = out.brake_pct;
+
+    /* Transition to POST_BRAKE — decel_target stays at DECEL_L3 */
+    pid_brake_step(DECEL_L3, 0.0F, (uint8_t)FSM_POST_BRAKE, &out);
+
+    TEST_ASSERT(out.brake_pct > 0.0F,
+        "braking continues in POST_BRAKE");
+
+    /* Verify output did not drop significantly during transition */
+    float32_t drop = pct_before_post - out.brake_pct;
+    if (drop < 0.0F) { drop = -drop; }
+    TEST_ASSERT(drop < 5.0F,
+        "brake output stable across BRAKE_L3 -> POST_BRAKE transition");
+}
+
+/**
+ * @brief Controller reset: integrator clears when returning to STANDBY.
+ */
+static void test_pid_reset_on_standby(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: reset on return to STANDBY\n");
+    pid_init();
+
+    /* Build up integrator in BRAKE_L1 */
+    uint8_t i = 0U;
+    for (i = 0U; i < 50U; i++)
+    {
+        pid_brake_step(DECEL_L1, 0.0F, (uint8_t)FSM_BRAKE_L1, &out);
+    }
+
+    /* Return to STANDBY */
+    pid_brake_step(0.0F, 0.0F, (uint8_t)FSM_STANDBY, &out);
+
+    TEST_ASSERT_FLOAT_EQ(out.brake_pct, 0.0F, 0.001F,
+        "brake_pct == 0 after returning to STANDBY");
+
+    /* Re-enter BRAKE_L1 — should start fresh */
+    pid_brake_step(DECEL_L1, 0.0F, (uint8_t)FSM_BRAKE_L1, &out);
+
+    TEST_ASSERT(out.brake_pct < 50.0F,
+        "first cycle after reset has no integrator carry-over");
+}
+
+/**
+ * @brief FR-BRK-001: No abrupt jumps > 2 m/s^2 between cycles.
+ */
+static void test_pid_no_abrupt_jumps(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+    float32_t prev_pct = 0.0F;
+    uint8_t smooth_ok = 1U;
+    float32_t max_jump_pct = 2.0F * (BRAKE_OUT_MAX / DECEL_L3);
+
+    printf("\n[TEST] pid: no deceleration jumps > 2 m/s^2\n");
+    pid_init();
+
+    uint8_t i = 0U;
+    for (i = 0U; i < 100U; i++)
+    {
+        pid_brake_step(DECEL_L3, 0.0F, (uint8_t)FSM_BRAKE_L3, &out);
+        float32_t delta = out.brake_pct - prev_pct;
+        if (delta < 0.0F) { delta = -delta; }
+
+        if (delta > max_jump_pct)
+        {
+            smooth_ok = 0U;
+        }
+        prev_pct = out.brake_pct;
+    }
+
+    TEST_ASSERT(smooth_ok == 1U,
+        "no jumps > 2 m/s^2 (33.3%) between cycles");
+}
+
+/**
+ * @brief Brake bar is always brake_pct / 10.
+ */
+static void test_pid_bar_conversion(void)
+{
+    pid_output_t out = {0.0F, 0.0F};
+
+    printf("\n[TEST] pid: bar = pct / 10\n");
+    pid_init();
+
+    uint8_t i = 0U;
+    for (i = 0U; i < 30U; i++)
+    {
+        pid_brake_step(DECEL_L2, 0.0F, (uint8_t)FSM_BRAKE_L2, &out);
+    }
+
+    TEST_ASSERT_FLOAT_EQ(out.brake_bar, out.brake_pct / 10.0F, 0.001F,
+        "brake_bar == brake_pct / 10");
+}
+
+/* ========================================================================= */
+/*  Main                                                                     */
+/* ========================================================================= */
+
+int main(void)
+{
+    printf("========================================\n");
+    printf("  AEB PID Controller — Unit Tests\n");
+    printf("========================================\n");
+
+    test_pid_no_braking_in_standby();
+    test_pid_no_braking_in_off();
+    test_pid_no_braking_in_warning();
+    test_pid_brake_l1_produces_output();
+    test_pid_output_clamping();
+    test_pid_jerk_limiting();
+    test_pid_steady_state_convergence();
+    test_pid_max_braking_capability();
+    test_pid_post_brake_hold();
+    test_pid_reset_on_standby();
+    test_pid_no_abrupt_jumps();
+    test_pid_bar_conversion();
+
+    printf("\n========================================\n");
+    printf("  Results: %d/%d passed, %d failed\n",
+           g_pass_count, g_test_count, g_fail_count);
+    printf("========================================\n");
+
+    return (g_fail_count > 0) ? 1 : 0;
+}


### PR DESCRIPTION
# Summary
- Implement PI brake controller with anti-windup and jerk limiting (aeb_pid.c)
- Implement alert mapping from FSM state to visual/audible outputs (aeb_alert.c)
- Implement driver override detection via brake pedal and steering angle (aeb_alert.c)
- Add aeb_pid.h and aeb_alert.h headers with alert/buzzer enumerations
- Add unit tests: 46 assertions, 46 passed across 2 test suites (test_pid.c, test_alert.c)
- MISRA C:2012 compliant: single exit point, const parameters, NULL guards, fixed-width types
- Address PR #54 review: remove doc/task_c, restore NULL checks and const qualifiers, replace task nomenclature with module names, fix dead variable in test

# Related Issue
Resolves #35, Resolves #36, Resolves #39

# Change Type
- [x] feat
- [ ] fix
- [ ] docs
- [x] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [x] Driver Alerts
- [x] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-BRK-001 to FR-BRK-007 (braking control)
- FR-ALR-001 to FR-ALR-004 (driver alerts)
- FR-DEC-006 (brake pedal override)
- FR-DEC-007 (steering override > 5 deg)

## Non-Functional Requirements
- NFR-COD-001 (MISRA C mandatory rules 100%)
- NFR-COD-002 (no malloc, no recursion)
- NFR-COD-003 (all variables initialised)
- NFR-COD-005 (fixed-width types)

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes
- [x] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence

Build command:
gcc -Wall -Wextra -Wpedantic -std=c99 -O2 -Iinclude -o test_pid_bin src/aeb_pid.c tests/test_pid.c -lm
gcc -Wall -Wextra -Wpedantic -std=c99 -O2 -Iinclude -o test_alert_bin src/aeb_alert.c tests/test_alert.c

PID tests: 19/19 passed
Alert tests: 27/27 passed
Total: 46/46 passed, 0 failed

Compiler: gcc -Wall -Wextra -Wpedantic -std=c99 -O2 — zero warnings

# Reviewer Notes
- Addresses all 6 items from PR #54 review by @renatosfagundes
- PI gains (Kp=10.0, Ki=0.05) match Simulink model AEB_Tasks Section 3.2
- alert_type_e and buzzer_cmd_e enums defined in aeb_alert.h (not in shared aeb_types.h)
- Buzzer enum values match Simulink chart_79 encoding (comment added explaining non-severity order)
- override_detect() reports general case; POST_BRAKE exception handled by FSM module
- NULL pointer guards added to alert_map() and pid_brake_step()
- const qualifiers restored on all pass-by-value parameters (MISRA Rule 8.13)
- Dead variable brake_before_post replaced with meaningful transition stability assertion

# Risks / Open Points
- Steady-state accuracy of PI controller depends on plant dynamics — full validation requires back-to-back SIL test (FR-COD-002) during integration
- alert_type_e and buzzer_cmd_e enums should be promoted to shared aeb_types.h during integration