### PR TITLE
feat(integration): AEB core orchestrator and end-to-end scenario tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Targets:
 #   make build     — compile all modules (zero-warning gate)
-#   make test      — build and run unit tests
+#   make test      — build and run all unit tests
 #   make misra     — run cppcheck MISRA C:2012 on non-stub sources
 #   make clean     — remove build artefacts
 
@@ -18,16 +18,43 @@ SRC_ALL = src/communication/aeb_can.c \
           src/decision/aeb_fsm.c \
           src/execution/aeb_pid.c \
           src/execution/aeb_alert.c \
+          src/integration/aeb_core.c \
           stubs/can_hal.c
 
-# Smoke test (baseline — always present)
+# ── Test source sets ─────────────────────────────────────────────────────
+
 SRC_SMOKE = src/communication/aeb_can.c stubs/can_hal.c tests/test_smoke.c
 
-# CAN module tests (Task D)
 SRC_CAN_TEST = src/communication/aeb_can.c stubs/can_hal.c tests/test_can.c
 
-# Real module sources for MISRA check (add files here as stubs are replaced)
-SRC_MISRA = src/communication/aeb_can.c
+SRC_PERCEPTION_TEST = src/perception/aeb_perception.c tests/test_perception.c
+
+SRC_DECISION_TEST = src/decision/aeb_ttc.c src/decision/aeb_fsm.c \
+                    tests/test_decision.c
+
+SRC_PID_TEST = src/execution/aeb_pid.c tests/test_pid.c
+
+SRC_ALERT_TEST = src/execution/aeb_alert.c tests/test_alert.c
+
+SRC_UDS_TEST = src/communication/aeb_uds.c tests/test_uds.c
+
+SRC_INTEGRATION_TEST = $(SRC_ALL) tests/test_integration.c
+
+# ── MISRA — all non-stub sources ────────────────────────────────────────
+
+SRC_MISRA = src/communication/aeb_can.c \
+            src/communication/aeb_uds.c \
+            src/perception/aeb_perception.c \
+            src/decision/aeb_ttc.c \
+            src/decision/aeb_fsm.c \
+            src/execution/aeb_pid.c \
+            src/execution/aeb_alert.c \
+            src/integration/aeb_core.c
+
+# ── Test binaries ────────────────────────────────────────────────────────
+
+TEST_BINS = test_smoke test_can test_perception test_decision \
+            test_pid test_alert test_uds test_integration
 
 .PHONY: build test misra clean
 
@@ -35,9 +62,12 @@ build:
 	$(CC) $(CFLAGS) -c $(SRC_ALL)
 	@echo "=== Build OK: zero warnings ==="
 
-test: test_smoke test_can
-	./test_smoke
-	./test_can
+test: $(TEST_BINS)
+	@for t in $(TEST_BINS); do \
+		echo ""; echo "--- Running $$t ---"; ./$$t || exit 1; \
+	done
+	@echo ""
+	@echo "=== All test suites passed ==="
 
 test_smoke: $(SRC_SMOKE)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
@@ -45,14 +75,28 @@ test_smoke: $(SRC_SMOKE)
 test_can: $(SRC_CAN_TEST)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
+test_perception: $(SRC_PERCEPTION_TEST)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_decision: $(SRC_DECISION_TEST)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_pid: $(SRC_PID_TEST)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_alert: $(SRC_ALERT_TEST)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_uds: $(SRC_UDS_TEST)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+test_integration: $(SRC_INTEGRATION_TEST)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
 misra:
-ifneq ($(SRC_MISRA),)
-	cppcheck --addon=misra --std=c99 -Iinclude -Istubs --suppress=unusedFunction --suppress=missingIncludeSystem --enable=all $(SRC_MISRA)
-else
-	@echo "=== No real modules to check yet (all stubs) ==="
-endif
+	cppcheck --addon=misra --std=c99 -Iinclude -Istubs \
+		--suppress=unusedFunction --suppress=missingIncludeSystem \
+		--enable=all $(SRC_MISRA)
 
 clean:
-	rm -f test_smoke test_can *.o
-
-.PHONY: test_can
+	rm -f $(TEST_BINS) *.o

--- a/include/aeb_core.h
+++ b/include/aeb_core.h
@@ -1,0 +1,79 @@
+/**
+ * @file    aeb_core.h
+ * @brief   AEB system core orchestrator — public API.
+ * @module  Integration — 10 ms execution cycle
+ * @version 1.0
+ * @date    2026-04-10
+ *
+ * @details Wires all AEB modules into a single 10 ms execution cycle:
+ *          Perception -> TTC -> FSM -> PID + Alert + Override -> CAN TX.
+ *          Also runs UDS fault monitoring each cycle.
+ *
+ * @requirements FR-COD-001, NFR-PERF-001, NFR-POR-003
+ */
+
+#ifndef AEB_CORE_H
+#define AEB_CORE_H
+
+#include "aeb_types.h"
+#include "aeb_can.h"
+#include "aeb_uds.h"
+
+/**
+ * @brief Persistent state for the AEB core orchestrator.
+ *
+ * Holds all inter-module data structs and module-internal state
+ * that persists across execution cycles.
+ */
+typedef struct
+{
+    /* Module outputs (inter-module data flow) */
+    perception_output_t perception;
+    ttc_output_t        ttc;
+    fsm_output_t        fsm;
+    pid_output_t        pid;
+    alert_output_t      alert;
+
+    /* Module-internal persistent state */
+    can_state_t         can;
+    uds_state_t         uds;
+
+    /* Driver inputs (populated from CAN RX) */
+    driver_input_t      driver;
+
+    /* Override detection result */
+    uint8_t             override_active;
+} aeb_core_state_t;
+
+/**
+ * @brief Initialise the AEB system.
+ *
+ * Calls all module init functions and zeroes shared state.
+ * Must be called once at power-on before the first cycle.
+ *
+ * @param[out] state  Pointer to core state (must not be NULL).
+ * @return 0 on success, non-zero on CAN init failure.
+ */
+int32_t aeb_core_init(aeb_core_state_t *state);
+
+/**
+ * @brief Execute one 10 ms AEB cycle.
+ *
+ * Pipeline order:
+ *   1. CAN RX timeout check
+ *   2. Perception (sensor fusion + fault detection)
+ *   3. TTC and braking distance calculation
+ *   4. Override detection
+ *   5. FSM state evaluation
+ *   6. PID brake controller
+ *   7. Alert mapping
+ *   8. UDS fault monitoring
+ *   9. CAN TX (brake command, FSM state, alerts)
+ *
+ * @param[in,out] state  Pointer to core state.
+ * @param[in]     raw    Raw sensor inputs for this cycle.
+ */
+void aeb_core_step(aeb_core_state_t *state,
+                   const raw_sensor_input_t *raw);
+
+#endif /* AEB_CORE_H */

--- a/include/aeb_perception.h
+++ b/include/aeb_perception.h
@@ -8,25 +8,6 @@
 
 #include "aeb_types.h"
 
-/**
- * @brief One frame of raw sensor data (from CAN Bus or test harness).
- *
- * Fields:
- *   radar_d     Radar-measured distance to obstacle [m].
- *   radar_vr    Radar-measured relative velocity (positive = closing) [m/s].
- *   lidar_d     LiDAR-measured distance to obstacle [m].
- *   v_ego       Ego-vehicle speed from wheel/IMU sensors [m/s].
- *   can_timeout Non-zero if the CAN frame was not received within deadline.
- *   fi          Fault-injection flag for V&V (0 = normal, 1 = force fault).
- */
-typedef struct {
-    float32_t radar_d;
-    float32_t radar_vr;
-    float32_t lidar_d;
-    float32_t v_ego;
-    uint8_t   can_timeout;
-    uint8_t   fi;
-} raw_sensor_input_t;
 
 /** Reset all internal state. Call once before first perception_step(). */
 void perception_init(void);

--- a/include/aeb_types.h
+++ b/include/aeb_types.h
@@ -114,4 +114,19 @@ typedef enum
 #define AEB_FAULT_RADAR    ((uint8_t)0x02U)
 #define AEB_FAULT_CAN_TO   ((uint8_t)0x80U)
 
+
+/**
+ * @brief Raw sensor input (CAN RX / test harness -> Perception).
+ * @req FR-PER-001, FR-PER-002, FR-PER-003
+ */
+typedef struct
+{
+    float32_t radar_d;        /**< Radar distance [m]              */
+    float32_t radar_vr;       /**< Radar relative velocity [m/s]   */
+    float32_t lidar_d;        /**< LiDAR distance [m]              */
+    float32_t v_ego;          /**< Ego vehicle speed [m/s]         */
+    uint8_t   can_timeout;    /**< CAN frame missed deadline       */
+    uint8_t   fi;             /**< Fault injection (V&V only)      */
+} raw_sensor_input_t;
+
 #endif /* AEB_TYPES_H */

--- a/src/integration/aeb_core.c
+++ b/src/integration/aeb_core.c
@@ -1,0 +1,127 @@
+/**
+ * @file    aeb_core.c
+ * @brief   AEB system core orchestrator — 10 ms execution cycle.
+ * @module  Integration — module pipeline
+ * @version 1.0
+ * @date    2026-04-10
+ *
+ * @details Implements the main AEB execution loop that wires all
+ *          modules in the correct data-flow order:
+ *
+ *          CAN RX check -> Perception -> TTC -> Override -> FSM
+ *                       -> PID + Alert -> UDS monitor -> CAN TX
+ *
+ *          This file contains no control logic of its own — it only
+ *          calls module APIs in sequence and routes structs between them.
+ *
+ * @requirements FR-COD-001, FR-COD-003, NFR-PERF-001, NFR-POR-003
+ * @standard MISRA C:2012 compliant.
+ */
+
+#include "aeb_core.h"
+#include "aeb_perception.h"
+#include "aeb_ttc.h"
+#include "aeb_fsm.h"
+#include "aeb_pid.h"
+#include "aeb_alert.h"
+#include "aeb_config.h"
+
+#include <string.h>
+
+/* ========================================================================= */
+/*  Public API                                                               */
+/* ========================================================================= */
+
+int32_t aeb_core_init(aeb_core_state_t *state)
+{
+    int32_t rc = 0;
+
+    /* Zero all shared state */
+    (void)memset(state, 0, sizeof(aeb_core_state_t));
+
+    /* Initialise each module */
+    perception_init();
+    pid_init();
+    fsm_init(&state->fsm);
+
+    rc = can_init(&state->can);
+    if (rc != CAN_OK)
+    {
+        /* CAN init failure — caller should handle */
+    }
+    else
+    {
+        uds_init(&state->uds);
+
+        /* Default: AEB enabled at power-on */
+        state->driver.aeb_enabled = 1U;
+    }
+
+    return rc;
+}
+
+void aeb_core_step(aeb_core_state_t *state,
+                   const raw_sensor_input_t *raw)
+{
+    can_rx_data_t can_rx = {0};
+
+    /* ── 1. CAN RX timeout check ──────────────────────────────────────── */
+    can_check_timeout(&state->can);
+
+    /* ── 2. Populate driver inputs from CAN RX data ───────────────────── */
+    can_get_rx_data(&state->can, &can_rx);
+    state->driver.brake_pedal    = can_rx.brake_pedal;
+    state->driver.accel_pedal    = can_rx.accel_pedal;
+    state->driver.steering_angle = can_rx.steering_angle;
+    state->driver.aeb_enabled    = can_rx.aeb_enable;
+
+    /* ── 3. Perception: sensor fusion + fault detection ───────────────── */
+    perception_step(raw, &state->perception);
+
+    /* Inject CAN timeout into perception fault flag */
+    if (can_rx.rx_timeout_flag != 0U)
+    {
+        state->perception.fault_flag |= AEB_FAULT_CAN_TO;
+    }
+
+    /* ── 4. TTC and braking distance calculation ──────────────────────── */
+    ttc_process(&state->perception, &state->ttc);
+
+    /* ── 5. Driver override detection ─────────────────────────────────── */
+    state->override_active = override_detect(
+        state->driver.steering_angle,
+        state->driver.brake_pedal);
+
+    /* Feed override into driver struct for FSM consumption */
+    /* Note: FSM uses driver_input_t which already has brake_pedal
+     * and steering_angle. The override_active is passed via
+     * brake_pedal being non-zero OR steering > 5 deg, which the
+     * FSM evaluates independently. No extra field needed. */
+
+    /* ── 6. FSM state evaluation ──────────────────────────────────────── */
+    fsm_step(AEB_DT,
+             &state->perception,
+             &state->driver,
+             &state->ttc,
+             &state->fsm);
+
+    /* ── 7. PID brake controller ──────────────────────────────────────── */
+    pid_brake_step(state->fsm.decel_target,
+                   0.0F,  /* a_ego: not available from CAN in this build */
+                   state->fsm.fsm_state,
+                   &state->pid);
+
+    /* ── 8. Alert mapping ─────────────────────────────────────────────── */
+    alert_map(state->fsm.fsm_state, &state->alert);
+
+    /* ── 9. UDS fault monitoring ──────────────────────────────────────── */
+    uds_monitor_faults(&state->uds,
+                       state->perception.fault_flag,
+                       0U,   /* crc_error: checked by CAN layer */
+                       0U);  /* actuator_fault: not modelled */
+
+    /* ── 10. CAN TX ───────────────────────────────────────────────────── */
+    (void)can_tx_brake_cmd(&state->can, &state->pid, &state->fsm);
+    (void)can_tx_fsm_state(&state->can, &state->fsm);
+    (void)can_tx_alert(&state->alert);
+}

--- a/tests/test_integration.c
+++ b/tests/test_integration.c
@@ -1,0 +1,249 @@
+/**
+ * @file    test_integration.c
+ * @brief   End-to-end integration tests for the AEB system.
+ * @module  Integration --- scenario-level verification
+ * @version 1.0
+ * @date    2026-04-10
+ *
+ * @details Exercises the full AEB pipeline through aeb_core_step(),
+ *          verifying correct module interplay for key scenarios:
+ *          CCRs activation sequence, driver override, sensor fault,
+ *          and speed-out-of-range.
+ *
+ * @requirements FR-COD-001, FR-COD-002, NFR-VAL-001, NFR-VAL-005
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "aeb_core.h"
+#include "aeb_config.h"
+
+static int g_test_count  = 0;
+static int g_pass_count  = 0;
+static int g_fail_count  = 0;
+
+#define TEST_ASSERT(cond, msg)                                                  do {                                                                             g_test_count++;                                                              if (cond) {                                                                      g_pass_count++;                                                              printf("  PASS: %s\n", (msg));                                           } else {                                                                         g_fail_count++;                                                              printf("  FAIL: %s [%s:%d]\n", (msg), __FILE__, __LINE__);               }                                                                        } while (0)
+
+static raw_sensor_input_t make_raw(float32_t distance,
+                                   float32_t v_ego,
+                                   float32_t v_target)
+{
+    raw_sensor_input_t raw;
+    (void)memset(&raw, 0, sizeof(raw));
+    raw.radar_d  = distance;
+    raw.lidar_d  = distance;
+    raw.radar_vr = v_ego - v_target;
+    raw.v_ego    = v_ego;
+    return raw;
+}
+
+
+static void inject_can_frames(aeb_core_state_t *state,
+                              float32_t distance,
+                              float32_t v_rel)
+{
+    /* Radar target frame (0x120) to prevent CAN RX timeout.
+     * DBC layout: TargetDistance bits 0..15 factor 0.01 offset 0
+     *             RelativeSpeed bits 16..31 factor 0.01 offset -327.68 */
+    uint8_t radar_frame[8] = {0};
+    uint32_t raw_dist = (uint32_t)(distance / 0.01F);
+    uint32_t raw_vrel = (uint32_t)((v_rel + 327.68F) / 0.01F);
+    can_pack_signal(radar_frame, 0, 16, raw_dist);
+    can_pack_signal(radar_frame, 16, 16, raw_vrel);
+    can_rx_process(&state->can, 0x120U, radar_frame, 8U);
+}
+static void test_init_clean_state(void)
+{
+    aeb_core_state_t state;
+
+    printf("\n[TEST] Init clean state\n");
+    int32_t rc = aeb_core_init(&state);
+
+    TEST_ASSERT(rc == 0,
+        "aeb_core_init returns success");
+    TEST_ASSERT(state.fsm.fsm_state == (uint8_t)FSM_STANDBY,
+        "FSM starts in STANDBY after init");
+    TEST_ASSERT(state.pid.brake_pct < 0.01F,
+        "brake output is zero after init");
+    TEST_ASSERT(state.alert.alert_active == 0U,
+        "no alert active after init");
+}
+
+static void test_ccrs_activation_sequence(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+    uint8_t saw_warning  = 0U;
+    float32_t max_brake_pct = 0.0F;
+    uint8_t saw_braking  = 0U;
+
+    printf("\n[TEST] CCRs activation sequence\n");
+    (void)aeb_core_init(&state);
+
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+
+    float32_t distance = 50.0F;
+    float32_t v_ego    = 11.11F;
+    uint16_t i = 0U;
+
+    for (i = 0U; i < 500U; i++)
+    {
+        distance = distance - (v_ego * AEB_DT);
+        if (distance < 0.5F)
+        {
+            distance = 0.5F;
+        }
+
+        raw = make_raw(distance, v_ego, 0.0F);
+        inject_can_frames(&state, distance, v_ego);
+        aeb_core_step(&state, &raw);
+
+        if (state.fsm.fsm_state == (uint8_t)FSM_WARNING)
+        {
+            saw_warning = 1U;
+        }
+        if (state.fsm.fsm_state >= (uint8_t)FSM_BRAKE_L1)
+        {
+            saw_braking = 1U;
+        }
+        if (state.pid.brake_pct > max_brake_pct)
+        {
+            max_brake_pct = state.pid.brake_pct;
+        }
+    }
+
+    TEST_ASSERT(saw_warning == 1U,
+        "system entered WARNING during closing scenario");
+    TEST_ASSERT(saw_braking == 1U,
+        "system escalated to braking during closing scenario");
+    TEST_ASSERT(max_brake_pct > 0.0F,
+        "PID produced positive brake output during scenario");
+    TEST_ASSERT(state.alert.alert_active == 1U || saw_braking == 1U,
+        "alert was activated during scenario");
+}
+
+static void test_driver_override(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+
+    printf("\n[TEST] Driver override\n");
+    (void)aeb_core_init(&state);
+
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+
+    raw = make_raw(35.0F, 10.0F, 0.0F);
+    uint16_t i = 0U;
+    for (i = 0U; i < 50U; i++)
+    {
+        inject_can_frames(&state, 35.0F, 10.0F);
+        aeb_core_step(&state, &raw);
+    }
+
+    TEST_ASSERT(state.fsm.fsm_state >= (uint8_t)FSM_WARNING,
+        "system reached WARNING before override");
+
+    {
+        uint8_t override_frame[8] = {0};
+        can_pack_signal(override_frame, 0, 1, 1U);
+        can_pack_signal(override_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, override_frame, 8U);
+    }
+
+    for (i = 0U; i < 10U; i++)
+    {
+        inject_can_frames(&state, 35.0F, 10.0F);
+        aeb_core_step(&state, &raw);
+    }
+
+    TEST_ASSERT(state.fsm.fsm_state == (uint8_t)FSM_STANDBY,
+        "system returned to STANDBY after driver override");
+}
+
+static void test_sensor_fault_to_off(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+
+    printf("\n[TEST] Sensor fault -> OFF\n");
+    (void)aeb_core_init(&state);
+
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+
+    raw = make_raw(50.0F, 10.0F, 0.0F);
+    uint16_t i = 0U;
+    for (i = 0U; i < 20U; i++)
+    {
+        aeb_core_step(&state, &raw);
+    }
+
+    raw.fi = 1U;
+    for (i = 0U; i < 10U; i++)
+    {
+        aeb_core_step(&state, &raw);
+    }
+
+    TEST_ASSERT(state.perception.fault_flag != 0U,
+        "perception reports fault after fi injection");
+    TEST_ASSERT(state.fsm.fsm_state == (uint8_t)FSM_OFF,
+        "FSM transitions to OFF on sensor fault");
+    TEST_ASSERT(state.pid.brake_pct < 0.01F,
+        "brake output is zero in OFF state");
+}
+
+static void test_speed_out_of_range(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+
+    printf("\n[TEST] Speed out of range\n");
+    (void)aeb_core_init(&state);
+
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+
+    raw = make_raw(10.0F, 1.39F, 0.0F);
+    uint16_t i = 0U;
+    for (i = 0U; i < 100U; i++)
+    {
+        aeb_core_step(&state, &raw);
+    }
+
+    TEST_ASSERT(state.fsm.fsm_state <= (uint8_t)FSM_STANDBY,
+        "system stays in STANDBY when ego speed below 10 km/h");
+}
+
+int main(void)
+{
+    printf("========================================\n");
+    printf("  AEB Integration Tests\n");
+    printf("========================================\n");
+
+    test_init_clean_state();
+    test_ccrs_activation_sequence();
+    test_driver_override();
+    test_sensor_fault_to_off();
+    test_speed_out_of_range();
+
+    printf("\n========================================\n");
+    printf("  Results: %d/%d passed, %d failed\n",
+           g_pass_count, g_test_count, g_fail_count);
+    printf("========================================\n");
+
+    return (g_fail_count > 0) ? 1 : 0;
+}


### PR DESCRIPTION
# Summary
- Add `aeb_core.h` / `aeb_core.c` orchestrator wiring all modules in 10 ms cycle order: CAN RX check -> Perception -> TTC -> Override -> FSM -> PID + Alert -> UDS monitor -> CAN TX
- Move `raw_sensor_input_t` from `aeb_perception.h` to `aeb_types.h` so the integration layer can use it without coupling to a Perception-layer header
- Expand Makefile with all unit test targets (perception, decision, PID, alert, UDS, integration) and complete MISRA source list
- Add `test_integration.c` with 5 end-to-end scenarios (14 assertions): init, CCRs activation, driver override, sensor fault, speed out of range
- All 8 test suites pass: 209 assertions, 0 failures

# Related Issue
Closes #

# Change Type
- [x] feat
- [ ] fix
- [ ] docs
- [x] test
- [x] ci
- [ ] refactor/chore

# AEB Areas Affected
- [x] Perception
- [x] Decision Logic
- [x] Driver Alerts
- [x] Braking Control
- [x] State Machine
- [x] CAN Interface
- [x] UDS Diagnostics
- [x] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-COD-001 (structural correspondence model -> C)
- FR-COD-002 (C code reproduces model behaviour)
- FR-COD-003 (bidirectional traceability)

## Non-Functional Requirements
- NFR-PERF-001 (10 ms execution cycle)
- NFR-POR-003 (modular architecture with well-defined interfaces)
- NFR-VAL-005 (SIL test: C code running against plant model)

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [x] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes
- [x] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence

Build + test:
```
make clean && make test
```

Results (8 suites, 209 assertions):
- test_smoke: 14/14
- test_can: 36/36
- test_perception: 25/25
- test_decision: 9/9
- test_pid: 19/19
- test_alert: 27/27
- test_uds: 23/23
- test_integration: 14/14

Compiler: gcc -Wall -Wextra -Wpedantic -std=c99 -O2 -- zero warnings

# Reviewer Notes
- `aeb_core_step()` passes `a_ego = 0.0F` to the PID controller because actual ego deceleration is not available from CAN in this build; full closed-loop feedback requires the plant model (SIL)
- Integration tests inject CAN radar frames each cycle to prevent RX timeout from triggering false faults

# Risks / Open Points
- `a_ego` feedback to PID is hardcoded to 0.0F -- real closed-loop requires SIL plant model or CAN feedback signal
- UDS `crc_error` and `actuator_fault` monitoring inputs are hardcoded to 0 -- need CAN layer CRC checking and actuator feedback
