### PR TITLE
docs(readme): add AI-assisted development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This modular structure supports portability, maintainability, and bidirectional 
 
 ## AI-Assisted Development
 
-This project used Large Language Model (LLM) assistants as a development support tool during the embedded C implementation phase. The use of AI was guided by the team's implementation strategy document (AEB_Tasks v1.0) and followed a structured prompt methodology to ensure consistency, traceability, and compliance with project standards.
+This project used Large Language Model (LLM) assistants as a development support tool during the embedded C implementation phase. The use of AI was guided by the team's implementation strategy document and followed a structured prompt methodology to ensure consistency, traceability, and compliance with project standards.
 
 ### Principles
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,38 @@ This modular structure supports portability, maintainability, and bidirectional 
 | Sensor fusion | ISO 15622 | ✅ Weighted radar + lidar |
 
 ---
+
+## AI-Assisted Development
+
+This project used Large Language Model (LLM) assistants as a development support tool during the embedded C implementation phase. The use of AI was guided by the team's implementation strategy document (AEB_Tasks v1.0) and followed a structured prompt methodology to ensure consistency, traceability, and compliance with project standards.
+
+### Principles
+
+All AI-generated code was treated as a **draft that requires human validation**. The following principles were applied throughout the project:
+
+1. **Human accountability** — Every team member remains fully responsible for the code submitted under their name. AI output was reviewed, tested, and modified before integration.
+2. **Specification-driven prompts** — Prompts were constructed from authoritative project artefacts: the SRS v2.0, the Simulink model (AEB_Integration.slx), the interface contract (`aeb_types.h`, `aeb_config.h`), and the applicable MISRA C:2012 rules.
+3. **Verification before commit** — All AI-generated code was compiled with strict warnings (`-Wall -Wextra -Wpedantic -std=c99`), validated against unit tests, and checked for MISRA compliance before being committed to the repository.
+4. **Traceability preserved** — AI-generated code follows the same requirement-to-code traceability as manually written code. Every function includes `@requirement` tags linking to SRS identifiers.
+
+### Tools Used
+
+| Tool | Provider | Usage |
+|---|---|---|
+| Claude (Opus / Sonnet) | Anthropic | Code generation, test creation, design documentation, code review preparation |
+| DeepSeek | DeepSeek AI | Code generation support |
+
+### Scope of AI Assistance
+
+| Activity | AI Role | Human Role |
+|---|---|---|
+| C module implementation | Generate initial code from structured prompts containing interface contracts, Simulink logic, and requirements | Review for correctness, MISRA compliance, and architectural consistency |
+| Unit test creation | Generate test cases covering requirement acceptance criteria and boundary conditions | Validate test logic, verify assertion correctness, add domain-specific scenarios |
+| Code review preparation | Draft PR descriptions and design rationale | Review and adjust content for accuracy |
+| MISRA compliance fixes | Suggest restructuring for single exit point, const qualifiers, NULL guards | Verify fix correctness and re-run static analysis |
+
+---
+
 ## Authors
 - Eryca Francyele de Moura e Silva
 - Jéssica Roberta de Souza Santos


### PR DESCRIPTION
# Summary
- Add AI-Assisted Development section to README.md
- Document the LLM tools used by the team (Claude and DeepSeek)
- Define principles for AI-assisted code generation: human accountability, specification-driven prompts, verification before commit, traceability preserved
- Detail scope of AI assistance with clear separation of AI role vs. human role per activity
- Describe limitations and safeguards applied to AI-generated output

# Related Issue
No related issue — documentation improvement.

# Change Type
- [ ] feat
- [ ] fix
- [x] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [x] Documentation only

# Requirements Impacted
## Functional Requirements
- None — documentation only, no functional change.

## Non-Functional Requirements
- NFR-COD-006 / NFR-COD-007 (indirectly: documents the process by which code coverage targets were achieved)
- NFR-POR-003 (indirectly: documents how modular architecture was maintained during AI-assisted development)

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [ ] C source code
- [ ] Tests
- [ ] CI workflow
- [x] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [ ] Automated tests pass
- [ ] CI passes
- [ ] Traceability updated
- [x] Safety-relevant impact assessed
- [x] Documentation updated

## Evidence
No code changes — README.md only. 

# Reviewer Notes
- Verify that the tools listed (Claude, DeepSeek) match what each team member actually used
- Confirm the team agrees with the principles stated (especially "human accountability" and "verification before commit")
- Check if any additional limitations or safeguards should be documented