### PR TITLE
fix: address PR #61 review — gitignore, task nomenclature, CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: AEB CI — Build, Test & MISRA Check
 
 on:
   pull_request:
-    branches: [development]
+    branches: [development, main]
   push:
-    branches: [development]
+    branches: [development, main]
 
 jobs:
   build-and-test:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 *.exe
 test_smoke
 test_can
+test_perception
+test_decision
+test_pid
+test_alert
+test_uds
+test_integration
 
 # IDE
 .vscode/

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -48,7 +48,7 @@
  * @brief Raw sensor data decoded from CAN RX frames.
  *
  * Populated by can_rx_process() from AEB_EgoVehicle (0x100) and
- * AEB_RadarTarget (0x120).  Consumed by Task A (Perception).
+ * AEB_RadarTarget (0x120).  Consumed by the Perception module.
  */
 typedef struct
 {
@@ -135,8 +135,8 @@ void can_check_timeout(can_state_t *state);
  * @brief Transmit AEB_BrakeCmd (0x080) — every 10 ms cycle.
  *
  * @param[in,out] state    Module state (alive counter incremented).
- * @param[in]     pid_out  PID brake output from Task C.
- * @param[in]     fsm_out  FSM output from Task B.
+ * @param[in]     pid_out  PID brake output from the PID module.
+ * @param[in]     fsm_out  FSM output from the FSM module.
  * @return CAN_OK on success, CAN_ERR_TX on failure.
  *
  * @req FR-CAN-003  DBC signal encoding.
@@ -149,7 +149,7 @@ int32_t can_tx_brake_cmd(can_state_t       *state,
  * @brief Transmit AEB_FSMState (0x200) — every 50 ms (5 × 10 ms ticks).
  *
  * @param[in,out] state    Module state (cycle counter checked).
- * @param[in]     fsm_out  FSM output from Task B.
+ * @param[in]     fsm_out  FSM output from the FSM module.
  * @return CAN_OK if transmitted, 1 if not yet due, CAN_ERR_TX on failure.
  *
  * @req FR-CAN-001  Transmit ego dynamics at fixed cycle.
@@ -160,7 +160,7 @@ int32_t can_tx_fsm_state(can_state_t       *state,
 /**
  * @brief Transmit AEB_Alert (0x300) — event-driven, call when alert changes.
  *
- * @param[in] alert_out  Alert output from Task C.
+ * @param[in] alert_out  Alert output from the Alert module.
  * @return CAN_OK on success, CAN_ERR_TX on failure.
  *
  * @req FR-CAN-003  DBC signal encoding.

--- a/src/decision/aeb_ttc.c
+++ b/src/decision/aeb_ttc.c
@@ -62,7 +62,7 @@ void ttc_process(const perception_output_t * const perception,
         return;
     }
 
-    /* FR-DEC-003: Use v_rel directly from perception (Task A already computed it) */
+    /* FR-DEC-003: Use v_rel directly from perception (the Perception module already computed it) */
     /* Set closing flag (v_rel > V_REL_MIN means approaching) */
     ttc_out->is_closing = (perception->v_rel > V_REL_MIN) ? 1U : 0U;
 

--- a/tests/test_perception.c
+++ b/tests/test_perception.c
@@ -1,6 +1,6 @@
 /**
  * @file    test_perception.c
- * @brief   Unit tests for the AEB Perception module (Task A).
+ * @brief   Unit tests for the AEB Perception module.
  *
  * Compile and run on PC (no Zephyr / hardware dependency):
  *


### PR DESCRIPTION
## Summary
- Add 6 missing test binaries (`test_perception`, `test_decision`, `test_pid`, `test_alert`, `test_uds`, `test_integration`) to `.gitignore`
- Replace 7 occurrences of internal "Task A/B/C" nomenclature with actual module names (Perception, FSM, PID, Alert) in `aeb_can.h`, `aeb_ttc.c`, and `test_perception.c`
- Add `main` branch to CI workflow `push` and `pull_request` triggers so releases are validated

## Related Issue
Ref #61

## Change Type
- [x] fix
- [x] ci

## AEB Areas Affected
- [x] Perception
- [x] Decision Logic
- [x] CAN Interface
- [x] Integration

## Requirements Impacted
### Functional Requirements
- N/A (no functional changes — comments and CI config only)

### Non-Functional Requirements
- NFR-COD-005..007 (code quality: removal of internal nomenclature from documentation)
- NFR-VAL-001 (CI coverage: main branch now validated)

## Artifacts Updated
- [x] C source code
- [x] Tests
- [x] CI workflow

## Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes
- [x] Safety-relevant impact assessed
- [x] Documentation updated

### Evidence
- Changes are limited to comments, `.gitignore`, and CI config — no functional code modified
- `make build` — zero-warning gate unaffected
- `make test` — all 209 assertions pass (no logic changes)
- Files modified: `.gitignore`, `include/aeb_can.h`, `src/decision/aeb_ttc.c`, `tests/test_perception.c`, `.github/workflows/ci.yml`
- No impact on CCRs / CCRm / CCRb scenarios

## Reviewer Notes
- All changes are non-functional: comments, `.gitignore` entries, and CI trigger config
- Verify that the  references listed in the PR #61 review are fully addressed

## Risks / Open Points
- None — no functional code changes
