### PR TITLE
fix(perception): robustness gaps from cross-validation V&V

### DIFF
--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -51,11 +51,10 @@ static uint8_t lidar_fault_detect(float32_t d_l)
     if (bad != 0U) {
         if (s_lidar.ctr < 255U) { s_lidar.ctr++; }
     } else {
-        s_lidar.ctr = 0U;
+        s_lidar.ctr      = 0U;
+        s_lidar.prev_d   = d_l;
+        s_lidar.is_first = 0U;
     }
-
-    s_lidar.prev_d   = d_l;
-    s_lidar.is_first = 0U;
 
     fault = (s_lidar.ctr >= (uint8_t)SENSOR_FAULT_CYCLES) ? 1U : 0U;
     return fault;
@@ -99,12 +98,11 @@ static uint8_t radar_fault_detect(float32_t d_r, float32_t vr_r)
     if (bad != 0U) {
         if (s_radar.ctr < 255U) { s_radar.ctr++; }
     } else {
-        s_radar.ctr = 0U;
+        s_radar.ctr      = 0U;
+        s_radar.prev_d   = d_r;
+        s_radar.prev_vr  = vr_r;
+        s_radar.is_first = 0U;
     }
-
-    s_radar.prev_d   = d_r;
-    s_radar.prev_vr  = vr_r;
-    s_radar.is_first = 0U;
 
     fault = (s_radar.ctr >= (uint8_t)SENSOR_FAULT_CYCLES) ? 1U : 0U;
     return fault;

--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -6,6 +6,7 @@
 #include "aeb_perception.h"
 #include "aeb_config.h"
 #include <stddef.h>
+#include <math.h>
 
 #define FABSF(x) (((x) < 0.0f) ? -(x) : (x))
 
@@ -38,7 +39,8 @@ static uint8_t lidar_fault_detect(float32_t d_l)
     uint8_t bad;
     uint8_t fault;
 
-    bad = ((d_l < LIDAR_DIST_MIN) || (d_l > LIDAR_DIST_MAX)) ? 1U : 0U;
+    bad = (!isfinite(d_l) ||
+           (d_l < LIDAR_DIST_MIN) || (d_l > LIDAR_DIST_MAX)) ? 1U : 0U;
 
     if ((s_lidar.is_first == 0U) && (bad == 0U)) {
         if (FABSF(d_l - s_lidar.prev_d) > DIST_ROC_LIMIT) {
@@ -83,7 +85,8 @@ static uint8_t radar_fault_detect(float32_t d_r, float32_t vr_r)
     uint8_t bad;
     uint8_t fault;
 
-    bad = ((d_r < RADAR_DIST_MIN) || (d_r > RADAR_DIST_MAX) ||
+    bad = (!isfinite(d_r) || !isfinite(vr_r) ||
+           (d_r < RADAR_DIST_MIN) || (d_r > RADAR_DIST_MAX) ||
            (FABSF(vr_r) > MAX_REL_VEL)) ? 1U : 0U;
 
     if ((s_radar.is_first == 0U) && (bad == 0U)) {
@@ -143,11 +146,11 @@ static void kalman_fusion(
     uint8_t l_fault, uint8_t r_fault, uint8_t fi,
     float32_t *out_d, float32_t *out_v, float32_t *out_conf)
 {
-    uint8_t l_ok = ((l_fault == 0U) && (fi == 0U)) ? 1U : 0U;
-    uint8_t r_ok = ((r_fault == 0U) && (fi == 0U)) ? 1U : 0U;
+    uint8_t l_ok = ((l_fault == 0U) && (fi == 0U) && isfinite(d_l)) ? 1U : 0U;
+    uint8_t r_ok = ((r_fault == 0U) && (fi == 0U) &&
+                    isfinite(d_r) && isfinite(vr_r)) ? 1U : 0U;
 
-    /* Seed state on first call: x = [d_r, vr_r] */
-    if (s_kalman.initialized == 0U) {
+    if ((s_kalman.initialized == 0U) && isfinite(d_r) && isfinite(vr_r)) {
         s_kalman.x[0] = d_r;
         s_kalman.x[1] = vr_r;
         s_kalman.initialized = 1U;

--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -51,6 +51,8 @@ static uint8_t lidar_fault_detect(float32_t d_l)
     if (bad != 0U) {
         if (s_lidar.ctr < 255U) { s_lidar.ctr++; }
     } else {
+        /* Update ROC baseline and arm is_first only on trustworthy frames —
+         * prevents a bad first frame from contaminating prev_d. */
         s_lidar.ctr      = 0U;
         s_lidar.prev_d   = d_l;
         s_lidar.is_first = 0U;
@@ -98,6 +100,8 @@ static uint8_t radar_fault_detect(float32_t d_r, float32_t vr_r)
     if (bad != 0U) {
         if (s_radar.ctr < 255U) { s_radar.ctr++; }
     } else {
+        /* Update ROC baseline and arm is_first only on trustworthy frames —
+         * prevents a bad first frame from contaminating prev_d/prev_vr. */
         s_radar.ctr      = 0U;
         s_radar.prev_d   = d_r;
         s_radar.prev_vr  = vr_r;
@@ -148,6 +152,8 @@ static void kalman_fusion(
     uint8_t r_ok = ((r_fault == 0U) && (fi == 0U) &&
                     isfinite(d_r) && isfinite(vr_r)) ? 1U : 0U;
 
+    /* Seed deferred until a finite radar frame; until then, l_ok/r_ok are
+     * both 0 and *out_conf below is forced to 0.0f — "no information" signalled. */
     if ((s_kalman.initialized == 0U) && isfinite(d_r) && isfinite(vr_r)) {
         s_kalman.x[0] = d_r;
         s_kalman.x[1] = vr_r;

--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -286,8 +286,14 @@ void perception_step(const raw_sensor_input_t *in, perception_output_t *out)
     float32_t fused_v;
     float32_t conf;
 
-    out->v_ego      = in->v_ego;
     out->fault_flag = 0U;
+
+    if (isfinite(in->v_ego)) {
+        out->v_ego = in->v_ego;
+    } else {
+        out->v_ego       = 0.0f;
+        out->fault_flag |= AEB_FAULT_CAN_TO;
+    }
 
     /* CAN timeout: hold last Kalman estimate, flag all faults */
     if (in->can_timeout != 0U) {


### PR DESCRIPTION
## Summary
Three fixes for the Perception module robustness gaps surfaced by the cross-validation V&V (fault-injection activity):

- Sensor fault detectors now guard against NaN / ±Inf inputs that previously propagated through the state machine and corrupted the rolling baseline.
- `v_ego` passthrough is sanitised; invalid values now propagate `AEB_FAULT_CAN_TO` instead of silently reaching downstream modules.
- The rate-of-change (ROC) baseline in both LiDAR and radar detectors is updated only on frames classified as good, eliminating the bad/good/bad cascade that previously latched a false fault.

## Related Issue
- Closes #79 — NaN / ±Inf guards in sensor fault detectors
- Closes #80 — `v_ego` passthrough sanitisation
- Closes #82 — ROC baseline only updated on good frames

## Change Type
- [x] fix

## AEB Areas Affected
- [x] Perception

## Requirements Impacted
**Non-Functional Requirements**
- NFR-SAF-ROB (sensor robustness — invalid input hardening across the perception pipeline)

## Artifacts Updated
- [x] C source code

## Validation Evidence
- [x] Local build passes (`make build` — zero warnings)
- [x] Automated tests pass (`make test` — 25 / 25 assertions in `test_perception.c` green after each commit, incremental verification)
- [ ] CI passes (automatic when the PR is opened)
- [ ] Full V&V stack re-run (`make vv-perception` — pending cross-validator on the branch, see Reviewer Notes)

## Evidence

| Bug | Location | Fix |
|---|---|---|
| #79 — NaN / ±Inf in fault detectors | `aeb_perception.c` (`lidar_fault_detect`, `radar_fault_detect`, `kalman_fusion`) | `#include <math.h>`; `!isfinite(...)` checks added to LiDAR/radar bad-frame classification; defence-in-depth `isfinite` guards on `l_ok` / `r_ok` in the Kalman step and on the Kalman state seed |
| #80 — `v_ego` passthrough | `aeb_perception.c` (`perception_step`) | Replaces unconditional `out->v_ego = in->v_ego;` with an `isfinite` gate; non-finite `v_ego` sets `AEB_FAULT_CAN_TO` instead of propagating |
| #82 — ROC baseline contamination | `aeb_perception.c` (`lidar_fault_detect`, `radar_fault_detect`) | Moves `prev_d`, `prev_vr`, and `is_first` updates into the good-frame `else` branch, so the ROC reference is only refreshed by trustworthy samples |

## Design Notes
The Bug #82 patch also moves `is_first = 0U` into the good-frame branch. This tightens the original semantics: the ROC test is now armed only once a trustworthy baseline has been observed, eliminating a first-frame-bad cascade (where an invalid first reading left `prev_d = 0` and the next good frame's ROC delta would still exceed the limit). Two nominal tests that previously relied on the earlier behaviour were re-verified against the tightened semantics and pass without modification.

## Reviewer Notes
@jessica-leoa — per ISO 26262-6 §5.4.8, the cross-validator re-runs the V&V stack on the branch after review: `make vv-perception`, confirming that the fault-injection assertions that previously failed now pass.

## Risks / Open Points
- No API changes — downstream modules see the same `perception_output_t` layout.
- The `NFR-SAF-ROB` gate on `make vv-perception` fault-injection is expected to flip from failing to passing after these commits; confirmed locally, awaiting cross-validator re-run on CI once the Perception V&V workflow lands (separate PR by the cross-validator).