### PR TITLE
fix(uds): address ASIL-D robustness gaps found in cross-validation

### DIFF
--- a/src/communication/aeb_uds.c
+++ b/src/communication/aeb_uds.c
@@ -17,6 +17,7 @@
 
 #include "aeb_uds.h"
 #include "aeb_config.h"
+#include <math.h>   /* isfinite() — Bug #1 defensive clamping */
 
 /* ===================================================================
  * Static helpers
@@ -79,6 +80,20 @@ static void uds_handle_read_did(const uds_request_t *request,
     {
         case UDS_DID_TTC_VAL:           /* 0xF100 */
         {
+            /* Bug #1 fix: validate float before cast to uint16_t.
+             * C11 §6.3.1.4: float->int cast is UB if out of range.
+             * Guards NaN, +/-Inf, negatives, and values exceeding
+             * UINT16_MAX after the x100 scaling (i.e. > 655.35). */
+            if (!isfinite(ttc_out->ttc) ||
+                (ttc_out->ttc < 0.0f)   ||
+                (ttc_out->ttc > 655.35f))
+            {
+                uds_send_negative(response,
+                                  UDS_SID_READ_DID,
+                                  UDS_NRC_REQUEST_OOR);
+                break;
+            }
+
             scaled_val = (uint16_t)(ttc_out->ttc * 100.0f);
 
             response->response_sid  = UDS_SID_READ_DID_RESP;
@@ -100,6 +115,19 @@ static void uds_handle_read_did(const uds_request_t *request,
 
         case UDS_DID_BRAKE_PRESS_VAL:   /* 0xF102 */
         {
+            /* Bug #1 fix: validate float before cast to uint16_t.
+             * Guards NaN, +/-Inf, negatives, and values exceeding
+             * UINT16_MAX after the x10 scaling (i.e. > 6553.5). */
+            if (!isfinite(pid_out->brake_pct) ||
+                (pid_out->brake_pct < 0.0f)   ||
+                (pid_out->brake_pct > 6553.5f))
+            {
+                uds_send_negative(response,
+                                  UDS_SID_READ_DID,
+                                  UDS_NRC_REQUEST_OOR);
+                break;
+            }
+
             scaled_val = (uint16_t)(pid_out->brake_pct * 10.0f);
 
             response->response_sid  = UDS_SID_READ_DID_RESP;
@@ -270,19 +298,21 @@ void uds_process_request(uds_state_t *state,
 
 void uds_get_output(const uds_state_t *state, uds_output_t *output)
 {
-    uint8_t count;
+    /* Bugs #2 and #3 fix: Boolean normalisation against SEU (single-event upset).
+     * Each flag is specified as Boolean (0 or 1), but a bit-flip from EMI,
+     * voltage glitch, or cosmic radiation may corrupt the raw byte to values
+     * like 0xAA or 0xFF. Without normalisation:
+     *   - aeb_enabled could be propagated as a non-Boolean, mis-read by
+     *     consumers using "== 1U" vs implicit truthiness tests.
+     *   - dtc_count (uint8_t sum of three flags) could overflow/wrap
+     *     (e.g. 3*0xFF = 0x2FD -> 0xFD), producing a nonsensical count.
+     * Normalising each flag via (x != 0U) ? 1U : 0U bounds the sum to [0..3]
+     * and delivers deterministic Boolean semantics to downstream consumers. */
+    uint8_t s = (state->dtc_sensor   != 0U) ? 1U : 0U;
+    uint8_t c = (state->dtc_crc      != 0U) ? 1U : 0U;
+    uint8_t a = (state->dtc_actuator != 0U) ? 1U : 0U;
 
-    output->aeb_enabled = state->aeb_enabled;
-
-    count = state->dtc_sensor + state->dtc_crc + state->dtc_actuator;
-    output->dtc_count = count;
-
-    if (count > 0U)
-    {
-        output->fault_lamp = 1U;
-    }
-    else
-    {
-        output->fault_lamp = 0U;
-    }
+    output->aeb_enabled = (state->aeb_enabled != 0U) ? 1U : 0U;
+    output->dtc_count   = (uint8_t)(s + c + a);                /* <= 3 */
+    output->fault_lamp  = (output->dtc_count > 0U) ? 1U : 0U;
 }


### PR DESCRIPTION
# Summary
- Apply three defensive patches in `src/communication/aeb_uds.c` identified by independent ASIL-D cross-validation (Relatório Consolidado V&V UDS, 21/04/2026).
- Bug 1 (HIGH): validate float inputs before `uint16_t` cast in `ReadDataByIdentifier` for DIDs `0xF100` (TTC) and `0xF102` (Brake), returning NRC `0x31` on NaN/±Inf/out-of-range.
- Bug 2 (CRITICAL, SEU): normalise `aeb_enabled` to strict Boolean in `uds_get_output` to defend against RAM bit-flips.
- Bug 3 (CRITICAL, SEU): normalise each DTC flag before summing `dtc_count` to prevent `uint8_t` wrap when flags are corrupted.
- Fixes converts fail-safe-by-coincidence (GCC 14 / x86-64) into fail-safe-by-design, independent of toolchain and optimisation level.
- No behavioural change for legitimate inputs: nominal suite (23/23) remains green.

## Related Issue
- Closes #70 
- Closes #71 
- Closes #72 

# Change Type
- [ ] feat
- [x] fix
- [ ] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [x] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-UDS-001 (ReadDataByIdentifier — robustness on input domain)
- FR-UDS-002 (DTC storage — Boolean integrity of flags)

## Non-Functional Requirements
- NFR-SAF-ROB (robustness against invalid inputs and SEU)

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [ ] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes
- [ ] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence
Patches implement exactly the fixes prescribed in Section 7 of the consolidated V&V report (Renato Fagundes, cross-validation):

- **Bug 1** (`aeb_uds.c:82` and `:103`): added `isfinite()` guard + range clamp `[0, 655.35]` for TTC and `[0, 6553.5]` for brake pressure; out-of-domain → `uds_send_negative(..., UDS_NRC_REQUEST_OOR)`.
- **Bug 2** (`aeb_uds.c:275`): `output->aeb_enabled = (state->aeb_enabled != 0U) ? 1U : 0U;`
- **Bug 3** (`aeb_uds.c:277`): per-flag Boolean normalisation before summing into `dtc_count`, bounding the result to `[0..3]`.

Expected post-merge validation (to be re-run by @Renato per report §8):
- `make vv-uds` → 18/18 fault-injection assertions PASS (was 11/18)
- `make memory-uds` → 0 UBSan `float-cast-overflow` diagnostics (was 2)
- `make test` → 23/23 nominal tests still PASS
- Structural coverage (statement/branch/MC/DC) remains at 100%.

Affected scenarios: diagnostic readout under sensor/actuator anomaly (NaN/Inf from upstream) and SEU-induced RAM corruption of Boolean state — both relevant to CCRs/CCRm/CCRb post-event diagnostics.

# Reviewer Notes
- Please verify that the range bounds `655.35f` (TTC) and `6553.5f` (brake_pct) correctly reflect the `UINT16_MAX / scale` limit for each DID encoding (DD-UDS-03).
- The `<math.h>` include is new in this file — added solely for `isfinite()`.
- Normalisation in `uds_get_output` does **not** protect against a bit-flip that toggles a legitimate `0` ↔ `1`; full SEU protection (redundant / CRC-protected state) is tracked as a follow-up system-level issue per report §7.2.

# Risks / Open Points
- Independence principle (ISO 26262-6 §5.4.8): re-validation must be executed by @Renato (original implementer ≠ validator). This PR intentionally does **not** modify tests.
- Residual SEU risk on legitimate Boolean values requires a separate systemic protection scheme (redundancy or CRC on `uds_state_t`) — out of scope for this PR.
- Traceability rows for FR-UDS-* and FR-COD-* in the Functional Excel pending (report §8, action #5).