### PR TITLE
feat(can-uds): integrate UDS over CAN (0x7DF/0x7E8)

### DIFF
--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -75,7 +75,27 @@ typedef struct
     uint8_t   aeb_enable;        /**< 0/1                                */
     uint8_t   driver_override;   /**< 0/1                                */
 
-    /* From UDS_Request (0x7DF) — FR-UDS-005 */
+    /* From UDS_Request (0x7DF) — FR-UDS-005
+     *
+     * Concurrency contract (IMPORTANT on Zephyr target):
+     *   can_rx_process()           writes uds_request_pending = 1 from the
+     *                              CAN RX callback context.
+     *   aeb_core_step()            reads-and-clears it from the 10 ms cycle
+     *                              thread.
+     *
+     *   On the host stub the two are called sequentially from the same
+     *   thread, so there is no race.  On the real Zephyr driver the RX
+     *   callback runs in a separate context; the driver integration layer
+     *   MUST serialise access — either by marshalling RX frames into a
+     *   message queue consumed by the core tick, by protecting this flag
+     *   with an atomic operation / brief interrupt disable around the
+     *   read-and-clear pair, or equivalent.
+     *
+     *   Without such synchronisation, a request arriving between the
+     *   read of uds_request_pending and the call to
+     *   can_clear_uds_request_pending() is silently dropped.  This is
+     *   not catchable at unit-test level because the host stub never
+     *   exercises the race — hence the documentation here. */
     uds_request_t uds_request;         /**< Decoded UDS request frame    */
     uint8_t       uds_request_pending; /**< 1 when a new request arrived;
                                             cleared by can_clear_uds_request_pending()

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -78,7 +78,8 @@ typedef struct
     /* From UDS_Request (0x7DF) — FR-UDS-005 */
     uds_request_t uds_request;         /**< Decoded UDS request frame    */
     uint8_t       uds_request_pending; /**< 1 when a new request arrived;
-                                            cleared by can_ack_uds_request() */
+                                            cleared by can_clear_uds_request_pending()
+                                            after the response transmits. */
 
     /* Status */
     uint8_t   rx_timeout_flag;   /**< 1 if radar RX timed out            */
@@ -203,15 +204,21 @@ void can_get_rx_data(const can_state_t *state,
 int32_t can_tx_uds_response(const uds_response_t *resp);
 
 /**
- * @brief Acknowledge the pending UDS request.
+ * @brief Mark the current UDS request as serviced and clear the pending flag.
  *
- * Clears the uds_request_pending flag after aeb_core_step() has serviced
- * the request.  Must be called exactly once per request to prevent
- * double-processing on the next cycle.
+ * The caller (aeb_core_step) is responsible for deciding *when* to call
+ * this — typically only after can_tx_uds_response() has confirmed the
+ * response transmitted successfully. Clearing the flag on TX failure
+ * silently drops the response and forces the requester into a P2_server
+ * timeout (ISO 14229-2 §6.3) instead of a best-effort retry at the ECU
+ * level. See aeb_core.c step 10 for the retry policy.
+ *
+ * Must be called exactly once per successfully-serviced request to
+ * prevent double-processing on the next cycle.
  *
  * @param[in,out] state  Module state.
  */
-void can_ack_uds_request(can_state_t *state);
+void can_clear_uds_request_pending(can_state_t *state);
 
 /* ── Signal encode/decode helpers (FR-CAN-003) ───────────────────────── */
 

--- a/include/aeb_can.h
+++ b/include/aeb_can.h
@@ -14,15 +14,18 @@
 
 #include "aeb_types.h"
 #include "aeb_config.h"
+#include "aeb_uds.h"
 #include <stdint.h>
 
 /* ── CAN Message IDs (from aeb_system.dbc) ───────────────────────────── */
-#define CAN_ID_BRAKE_CMD      (0x080U)   /**< 128 — AEB_BrakeCmd  TX     */
-#define CAN_ID_EGO_VEHICLE    (0x100U)   /**< 256 — AEB_EgoVehicle RX    */
-#define CAN_ID_DRIVER_INPUT   (0x101U)   /**< 257 — AEB_DriverInput RX   */
-#define CAN_ID_RADAR_TARGET   (0x120U)   /**< 288 — AEB_RadarTarget RX   */
-#define CAN_ID_FSM_STATE      (0x200U)   /**< 512 — AEB_FSMState TX      */
-#define CAN_ID_ALERT          (0x300U)   /**< 768 — AEB_Alert TX         */
+#define CAN_ID_BRAKE_CMD      (0x080U)   /**< 128  — AEB_BrakeCmd   TX    */
+#define CAN_ID_EGO_VEHICLE    (0x100U)   /**< 256  — AEB_EgoVehicle RX    */
+#define CAN_ID_DRIVER_INPUT   (0x101U)   /**< 257  — AEB_DriverInput RX   */
+#define CAN_ID_RADAR_TARGET   (0x120U)   /**< 288  — AEB_RadarTarget RX   */
+#define CAN_ID_FSM_STATE      (0x200U)   /**< 512  — AEB_FSMState   TX    */
+#define CAN_ID_ALERT          (0x300U)   /**< 768  — AEB_Alert      TX    */
+#define CAN_ID_UDS_REQUEST    (0x7DFU)   /**< 2015 — UDS_Request    RX    */
+#define CAN_ID_UDS_RESPONSE   (0x7E8U)   /**< 2024 — UDS_Response   TX    */
 
 /* ── CAN Frame Lengths (bytes) ───────────────────────────────────────── */
 #define CAN_DLC_BRAKE_CMD     (4U)
@@ -31,6 +34,8 @@
 #define CAN_DLC_RADAR_TARGET  (8U)
 #define CAN_DLC_FSM_STATE     (4U)
 #define CAN_DLC_ALERT         (2U)
+#define CAN_DLC_UDS_REQUEST   (4U)
+#define CAN_DLC_UDS_RESPONSE  (8U)
 
 /* ── RX Timeout ──────────────────────────────────────────────────────── */
 #define CAN_RX_TIMEOUT_CYCLES (3U)  /**< 3 missed frames → fault        */
@@ -70,6 +75,11 @@ typedef struct
     uint8_t   aeb_enable;        /**< 0/1                                */
     uint8_t   driver_override;   /**< 0/1                                */
 
+    /* From UDS_Request (0x7DF) — FR-UDS-005 */
+    uds_request_t uds_request;         /**< Decoded UDS request frame    */
+    uint8_t       uds_request_pending; /**< 1 when a new request arrived;
+                                            cleared by can_ack_uds_request() */
+
     /* Status */
     uint8_t   rx_timeout_flag;   /**< 1 if radar RX timed out            */
 } can_rx_data_t;
@@ -103,8 +113,9 @@ int32_t can_init(can_state_t *state);
 /**
  * @brief Process a single received CAN frame (called from RX callback).
  *
- * Decodes EgoVehicle (0x100) or RadarTarget (0x120) per DBC layout.
- * Resets the RX miss counter on valid frame.
+ * Decodes EgoVehicle (0x100), RadarTarget (0x120), DriverInput (0x101)
+ * or UDS_Request (0x7DF) per DBC layout.  Resets the RX miss counter
+ * on valid radar frame.  A valid 0x7DF frame sets uds_request_pending.
  *
  * @param[in,out] state  Module state.
  * @param[in]     id     CAN message ID.
@@ -113,6 +124,7 @@ int32_t can_init(can_state_t *state);
  *
  * @req FR-CAN-002  Receive radar target data.
  * @req FR-CAN-003  DBC signal encoding.
+ * @req FR-UDS-005  Receive UDS request on 0x7DF.
  */
 void can_rx_process(can_state_t *state,
                     uint32_t     id,
@@ -175,6 +187,31 @@ int32_t can_tx_alert(const alert_output_t *alert_out);
  */
 void can_get_rx_data(const can_state_t *state,
                      can_rx_data_t     *out);
+
+/**
+ * @brief Transmit a UDS response frame on CAN_ID_UDS_RESPONSE (0x7E8).
+ *
+ * Packs the 8-byte uds_response_t into a CAN frame and sends via HAL.
+ * Called from aeb_core_step() after uds_process_request() produces a
+ * response for a pending 0x7DF request.
+ *
+ * @param[in] resp  UDS response to transmit.
+ * @return CAN_OK on success, CAN_ERR_TX on failure.
+ *
+ * @req FR-UDS-005  UDS request/response via CAN within one cycle.
+ */
+int32_t can_tx_uds_response(const uds_response_t *resp);
+
+/**
+ * @brief Acknowledge the pending UDS request.
+ *
+ * Clears the uds_request_pending flag after aeb_core_step() has serviced
+ * the request.  Must be called exactly once per request to prevent
+ * double-processing on the next cycle.
+ *
+ * @param[in,out] state  Module state.
+ */
+void can_ack_uds_request(can_state_t *state);
 
 /* ── Signal encode/decode helpers (FR-CAN-003) ───────────────────────── */
 

--- a/include/aeb_core.h
+++ b/include/aeb_core.h
@@ -60,15 +60,16 @@ int32_t aeb_core_init(aeb_core_state_t *state);
  * @brief Execute one 10 ms AEB cycle.
  *
  * Pipeline order:
- *   1. CAN RX timeout check
- *   2. Perception (sensor fusion + fault detection)
- *   3. TTC and braking distance calculation
- *   4. Override detection
- *   5. FSM state evaluation
- *   6. PID brake controller
- *   7. Alert mapping
- *   8. UDS fault monitoring
- *   9. CAN TX (brake command, FSM state, alerts)
+ *   1.  CAN RX timeout check
+ *   2.  Perception (sensor fusion + fault detection)
+ *   3.  TTC and braking distance calculation
+ *   4.  Override detection
+ *   5.  FSM state evaluation
+ *   6.  PID brake controller
+ *   7.  Alert mapping
+ *   8.  UDS fault monitoring
+ *   9.  UDS request service (0x7DF → 0x7E8, FR-UDS-005)
+ *   10. CAN TX (brake command, FSM state, alerts)
  *
  * @param[in,out] state  Pointer to core state.
  * @param[in]     raw    Raw sensor inputs for this cycle.

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -512,8 +512,11 @@ int32_t can_tx_uds_response(const uds_response_t *resp)
 
 /**
  * @brief Clear the pending UDS request flag after it has been serviced.
+ *
+ * Must only be called after can_tx_uds_response() reported CAN_OK.
+ * See aeb_can.h for the retry semantics rationale.
  */
-void can_ack_uds_request(can_state_t *state)
+void can_clear_uds_request_pending(can_state_t *state)
 {
     if (state != NULL)
     {

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -166,10 +166,11 @@ int32_t can_init(can_state_t *state)
     }
     else
     {
-        /* Register RX filters for the three messages we receive */
+        /* Register RX filters for the messages we receive */
         (void)can_hal_add_rx_filter(CAN_ID_EGO_VEHICLE);
         (void)can_hal_add_rx_filter(CAN_ID_DRIVER_INPUT);
         (void)can_hal_add_rx_filter(CAN_ID_RADAR_TARGET);
+        (void)can_hal_add_rx_filter(CAN_ID_UDS_REQUEST);
 
         state->initialised = 1U;
     }
@@ -255,6 +256,20 @@ void can_rx_process(can_state_t   *state,
             /* Valid frame received — reset miss counter */
             state->rx_miss_count = 0U;
             state->last_rx.rx_timeout_flag = 0U;
+        }
+    }
+    else if (id == CAN_ID_UDS_REQUEST)
+    {
+        /* UDS_Request (0x7DF) — ISO 14229 functional broadcast.
+         * 4-byte payload mapped directly to uds_request_t.
+         * FR-UDS-005: request serviced within same 10 ms cycle. */
+        if (dlc >= CAN_DLC_UDS_REQUEST)
+        {
+            state->last_rx.uds_request.sid      = data[0];
+            state->last_rx.uds_request.did_high = data[1];
+            state->last_rx.uds_request.did_low  = data[2];
+            state->last_rx.uds_request.value    = data[3];
+            state->last_rx.uds_request_pending  = 1U;
         }
     }
     else
@@ -457,5 +472,51 @@ void can_get_rx_data(const can_state_t *state,
     if ((state != NULL) && (out != NULL))
     {
         (void)memcpy(out, &state->last_rx, sizeof(can_rx_data_t));
+    }
+}
+
+/**
+ * @brief Transmit UDS_Response (0x7E8).
+ * @req FR-UDS-005
+ */
+int32_t can_tx_uds_response(const uds_response_t *resp)
+{
+    int32_t result = CAN_OK;
+
+    if (resp == NULL)
+    {
+        result = CAN_ERR_TX;
+    }
+    else
+    {
+        uint8_t frame[8];
+
+        /* uds_response_t is an 8-byte wire-format struct — map 1:1. */
+        frame[0] = resp->response_sid;
+        frame[1] = resp->did_high_resp;
+        frame[2] = resp->did_low_resp;
+        frame[3] = resp->data1;
+        frame[4] = resp->data2;
+        frame[5] = resp->data3;
+        frame[6] = resp->data4;
+        frame[7] = resp->data5;
+
+        if (can_hal_send(CAN_ID_UDS_RESPONSE, frame, CAN_DLC_UDS_RESPONSE) != 0)
+        {
+            result = CAN_ERR_TX;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * @brief Clear the pending UDS request flag after it has been serviced.
+ */
+void can_ack_uds_request(can_state_t *state)
+{
+    if (state != NULL)
+    {
+        state->last_rx.uds_request_pending = 0U;
     }
 }

--- a/src/integration/aeb_core.c
+++ b/src/integration/aeb_core.c
@@ -122,6 +122,12 @@ void aeb_core_step(aeb_core_state_t *state,
                        0U);  /* actuator_fault: not modelled */
 
     /* ── 10. UDS request service — FR-UDS-005 (same-cycle response) ───── */
+    /* Retry policy: on TX failure (bus-off, TX mailbox full, HAL error)
+     * we leave uds_request_pending = 1 so the next 10 ms tick retries the
+     * transmission. Silently clearing would force the requester into a
+     * P2_server timeout per ISO 14229-2 §6.3 instead of the best-effort
+     * retry at the ECU level that ASIL-D prefers for an idempotent DID
+     * read / short RoutineControl request. */
     if (can_rx.uds_request_pending != 0U)
     {
         uds_response_t uds_resp = {0};
@@ -132,8 +138,10 @@ void aeb_core_step(aeb_core_state_t *state,
                             &state->fsm,
                             &state->pid,
                             &state->ttc);
-        (void)can_tx_uds_response(&uds_resp);
-        can_ack_uds_request(&state->can);
+        if (can_tx_uds_response(&uds_resp) == CAN_OK)
+        {
+            can_clear_uds_request_pending(&state->can);
+        }
     }
 
     /* ── 11. CAN TX ───────────────────────────────────────────────────── */

--- a/src/integration/aeb_core.c
+++ b/src/integration/aeb_core.c
@@ -9,7 +9,8 @@
  *          modules in the correct data-flow order:
  *
  *          CAN RX check -> Perception -> TTC -> Override -> FSM
- *                       -> PID + Alert -> UDS monitor -> CAN TX
+ *                       -> PID + Alert -> UDS monitor -> UDS request
+ *                       -> CAN TX
  *
  *          This file contains no control logic of its own — it only
  *          calls module APIs in sequence and routes structs between them.
@@ -120,7 +121,22 @@ void aeb_core_step(aeb_core_state_t *state,
                        0U,   /* crc_error: checked by CAN layer */
                        0U);  /* actuator_fault: not modelled */
 
-    /* ── 10. CAN TX ───────────────────────────────────────────────────── */
+    /* ── 10. UDS request service — FR-UDS-005 (same-cycle response) ───── */
+    if (can_rx.uds_request_pending != 0U)
+    {
+        uds_response_t uds_resp = {0};
+
+        uds_process_request(&state->uds,
+                            &can_rx.uds_request,
+                            &uds_resp,
+                            &state->fsm,
+                            &state->pid,
+                            &state->ttc);
+        (void)can_tx_uds_response(&uds_resp);
+        can_ack_uds_request(&state->can);
+    }
+
+    /* ── 11. CAN TX ───────────────────────────────────────────────────── */
     (void)can_tx_brake_cmd(&state->can, &state->pid, &state->fsm);
     (void)can_tx_fsm_state(&state->can, &state->fsm);
     (void)can_tx_alert(&state->alert);

--- a/stubs/can_hal.c
+++ b/stubs/can_hal.c
@@ -7,17 +7,11 @@
  */
 
 #include "can_hal.h"
+#include "can_hal_test.h"
 #include <string.h>
 
 /* ── TX capture buffer for test inspection ──────────────────────────── */
 #define TX_BUF_SIZE  (32U)
-
-typedef struct
-{
-    uint32_t id;
-    uint8_t  data[8];
-    uint8_t  dlc;
-} tx_record_t;
 
 static tx_record_t tx_buffer[TX_BUF_SIZE];
 static uint32_t    tx_count = 0U;

--- a/stubs/can_hal_test.h
+++ b/stubs/can_hal_test.h
@@ -1,0 +1,29 @@
+/**
+ * @file  can_hal_test.h
+ * @brief Test-only helpers exposed by the CAN HAL stub.
+ *
+ * Included only by unit tests.  Gives tests read access to the TX
+ * capture buffer and fault-injection hooks used to drive error paths.
+ * The real Zephyr CAN driver does not provide these — they are
+ * specific to the host-side stub in can_hal.c.
+ */
+
+#ifndef CAN_HAL_TEST_H
+#define CAN_HAL_TEST_H
+
+#include <stdint.h>
+
+typedef struct
+{
+    uint32_t id;
+    uint8_t  data[8];
+    uint8_t  dlc;
+} tx_record_t;
+
+void                 can_hal_test_reset(void);
+uint32_t             can_hal_test_get_tx_count(void);
+const tx_record_t   *can_hal_test_get_tx(uint32_t index);
+void                 can_hal_test_force_init_fail(int32_t fail);
+void                 can_hal_test_force_send_fail(int32_t fail);
+
+#endif /* CAN_HAL_TEST_H */

--- a/tests/test_can.c
+++ b/tests/test_can.c
@@ -8,6 +8,7 @@
 
 #include "aeb_can.h"
 #include "can_hal.h"
+#include "can_hal_test.h"
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -33,11 +34,7 @@ static int32_t tests_failed = 0;
 #define TEST(name) static void name(void)
 #define RUN(name) do { printf("  [TEST] %s\n", #name); name(); } while (0)
 
-/* ── Extern test helpers from can_hal.c stub ────────────────────────── */
-extern uint32_t       can_hal_test_get_tx_count(void);
-extern void           can_hal_test_reset(void);
-extern void           can_hal_test_force_init_fail(int32_t fail);
-extern void           can_hal_test_force_send_fail(int32_t fail);
+/* Test helpers from the CAN HAL stub are declared in can_hal_test.h */
 
 /* ═══════════════════════════════════════════════════════════════════════
  *  TEST: Signal pack/unpack round-trip  (FR-CAN-003)
@@ -336,6 +333,84 @@ TEST(test_tx_send_failure)
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — UDS Request (0x7DF)  (FR-UDS-005)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_uds_request)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* ReadDID 0xF101 (FSM state) — 4 bytes: {SID, DID_H, DID_L, value} */
+    uint8_t frame[4] = { 0x22U, 0xF1U, 0x01U, 0x00U };
+
+    can_rx_process(&state, CAN_ID_UDS_REQUEST, frame, CAN_DLC_UDS_REQUEST);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_EQ(rx.uds_request_pending, 1U);
+    ASSERT_EQ(rx.uds_request.sid, 0x22U);
+    ASSERT_EQ(rx.uds_request.did_high, 0xF1U);
+    ASSERT_EQ(rx.uds_request.did_low, 0x01U);
+    ASSERT_EQ(rx.uds_request.value, 0x00U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: TX UDS Response (0x7E8)  (FR-UDS-005)
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_tx_uds_response)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    uds_response_t resp;
+    resp.response_sid   = 0x62U;   /* Positive response to 0x22 */
+    resp.did_high_resp  = 0xF1U;
+    resp.did_low_resp   = 0x01U;
+    resp.data1          = (uint8_t)FSM_STANDBY;
+    resp.data2          = 0x00U;
+    resp.data3          = 0x00U;
+    resp.data4          = 0x00U;
+    resp.data5          = 0x00U;
+
+    int32_t rc = can_tx_uds_response(&resp);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+
+    const tx_record_t *tx = can_hal_test_get_tx(0U);
+    ASSERT_EQ(tx->id, (uint32_t)CAN_ID_UDS_RESPONSE);
+    ASSERT_EQ(tx->dlc, CAN_DLC_UDS_RESPONSE);
+    ASSERT_EQ(tx->data[0], 0x62U);
+    ASSERT_EQ(tx->data[1], 0xF1U);
+    ASSERT_EQ(tx->data[2], 0x01U);
+    ASSERT_EQ(tx->data[3], (uint8_t)FSM_STANDBY);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: UDS request ack clears the pending flag
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_uds_request_ack)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    uint8_t frame[4] = { 0x22U, 0xF1U, 0x01U, 0x00U };
+    can_rx_process(&state, CAN_ID_UDS_REQUEST, frame, CAN_DLC_UDS_REQUEST);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+    ASSERT_EQ(rx.uds_request_pending, 1U);
+
+    can_ack_uds_request(&state);
+
+    can_get_rx_data(&state, &rx);
+    ASSERT_EQ(rx.uds_request_pending, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
  *  MAIN
  * ═══════════════════════════════════════════════════════════════════════ */
 int main(void)
@@ -355,6 +430,9 @@ int main(void)
     RUN(test_tx_brake_cmd);
     RUN(test_tx_fsm_period);
     RUN(test_tx_send_failure);
+    RUN(test_rx_uds_request);
+    RUN(test_tx_uds_response);
+    RUN(test_uds_request_ack);
 
     printf("\n=== Results: %d run, %d passed, %d failed ===\n",
            tests_run, tests_passed, tests_failed);

--- a/tests/test_can.c
+++ b/tests/test_can.c
@@ -404,7 +404,7 @@ TEST(test_uds_request_ack)
     can_get_rx_data(&state, &rx);
     ASSERT_EQ(rx.uds_request_pending, 1U);
 
-    can_ack_uds_request(&state);
+    can_clear_uds_request_pending(&state);
 
     can_get_rx_data(&state, &rx);
     ASSERT_EQ(rx.uds_request_pending, 0U);

--- a/tests/test_can.c
+++ b/tests/test_can.c
@@ -389,6 +389,32 @@ TEST(test_tx_uds_response)
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
+ *  TEST: RX decode — UDS Request with short DLC is rejected (FR-UDS-005)
+ *
+ *  Contract: can_rx_process() only accepts 0x7DF frames with
+ *  DLC == CAN_DLC_UDS_REQUEST (4). Shorter frames must leave
+ *  uds_request_pending at 0 so aeb_core_step() observes a no-op.
+ *  This locks the malformed-frame behaviour that was previously
+ *  implicit.
+ * ═══════════════════════════════════════════════════════════════════════ */
+TEST(test_rx_uds_request_short_dlc)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* Only 3 bytes — missing the value field. */
+    uint8_t frame[3] = { 0x22U, 0xF1U, 0x01U };
+
+    can_rx_process(&state, CAN_ID_UDS_REQUEST, frame, 3U);
+
+    can_rx_data_t rx;
+    can_get_rx_data(&state, &rx);
+
+    ASSERT_EQ(rx.uds_request_pending, 0U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
  *  TEST: UDS request ack clears the pending flag
  * ═══════════════════════════════════════════════════════════════════════ */
 TEST(test_uds_request_ack)
@@ -431,6 +457,7 @@ int main(void)
     RUN(test_tx_fsm_period);
     RUN(test_tx_send_failure);
     RUN(test_rx_uds_request);
+    RUN(test_rx_uds_request_short_dlc);
     RUN(test_tx_uds_response);
     RUN(test_uds_request_ack);
 

--- a/tests/test_integration.c
+++ b/tests/test_integration.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include "aeb_core.h"
 #include "aeb_config.h"
+#include "can_hal_test.h"
 
 static int g_test_count  = 0;
 static int g_pass_count  = 0;
@@ -203,6 +204,74 @@ static void test_sensor_fault_to_off(void)
         "brake output is zero in OFF state");
 }
 
+/* Scan the HAL TX capture buffer for a frame with the given CAN ID.
+ * Returns the matching record, or NULL if not present. */
+static const tx_record_t *find_tx(uint32_t id)
+{
+    uint32_t n = can_hal_test_get_tx_count();
+    uint32_t i = 0U;
+    const tx_record_t *hit = NULL;
+
+    for (i = 0U; i < n; i++)
+    {
+        const tx_record_t *rec = can_hal_test_get_tx(i);
+        if ((rec != NULL) && (rec->id == id))
+        {
+            hit = rec;
+        }
+    }
+    return hit;
+}
+
+static void test_uds_request_response_roundtrip(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+
+    printf("\n[TEST] UDS request/response round-trip (0x7DF -> 0x7E8)\n");
+    (void)aeb_core_init(&state);
+    can_hal_test_reset();
+
+    /* Benign scenario — AEB enabled, stopped ego, far non-closing target.
+     * FSM stays in STANDBY so DID 0xF101 returns a known value.
+     * The roundtrip contract we care about is CAN path, not FSM dynamics. */
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);   /* aeb_enable */
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+    inject_can_frames(&state, 100.0F, 0.0F);
+
+    uint8_t req[4] = { 0x22U, 0xF1U, 0x01U, 0x00U };
+    can_rx_process(&state.can, CAN_ID_UDS_REQUEST, req, CAN_DLC_UDS_REQUEST);
+
+    /* Run one full cycle — step 10 services the request,
+     * step 11 transmits.  We scan the TX buffer for the 0x7E8 record. */
+    raw = make_raw(100.0F, 0.0F, 0.0F);
+    aeb_core_step(&state, &raw);
+
+    const tx_record_t *resp = find_tx(CAN_ID_UDS_RESPONSE);
+    TEST_ASSERT(resp != NULL,
+        "UDS response frame 0x7E8 was transmitted in same cycle");
+    if (resp != NULL)
+    {
+        TEST_ASSERT(resp->dlc == CAN_DLC_UDS_RESPONSE,
+            "UDS response DLC is 8");
+        TEST_ASSERT(resp->data[0] == 0x62U,
+            "positive ReadDID response SID (0x62)");
+        TEST_ASSERT(resp->data[1] == 0xF1U && resp->data[2] == 0x01U,
+            "response echoes DID 0xF101");
+        TEST_ASSERT(resp->data[3] == (uint8_t)FSM_STANDBY,
+            "response reports current FSM state (STANDBY) in data1");
+    }
+
+    /* After service, the pending flag must be cleared. */
+    can_rx_data_t rx;
+    can_get_rx_data(&state.can, &rx);
+    TEST_ASSERT(rx.uds_request_pending == 0U,
+        "pending flag cleared after one cycle");
+}
+
 static void test_speed_out_of_range(void)
 {
     aeb_core_state_t state;
@@ -239,6 +308,7 @@ int main(void)
     test_driver_override();
     test_sensor_fault_to_off();
     test_speed_out_of_range();
+    test_uds_request_response_roundtrip();
 
     printf("\n========================================\n");
     printf("  Results: %d/%d passed, %d failed\n",

--- a/tests/test_integration.c
+++ b/tests/test_integration.c
@@ -272,6 +272,83 @@ static void test_uds_request_response_roundtrip(void)
         "pending flag cleared after one cycle");
 }
 
+/* ISO 14229 negative-response flow through the full pipeline:
+ * an unknown SID produces SID 0x7F + NRC 0x11 (Service Not Supported);
+ * a supported SID with an unknown DID produces SID 0x7F + NRC 0x31
+ * (Request Out Of Range). In both cases the response MUST still go out
+ * on 0x7E8 — silence would force the client into a P2 timeout. */
+static void test_uds_negative_response_unknown_sid(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+
+    printf("\n[TEST] UDS negative response — unknown SID\n");
+    (void)aeb_core_init(&state);
+    can_hal_test_reset();
+
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+    inject_can_frames(&state, 100.0F, 0.0F);
+
+    /* SID 0xAA is not in the supported set (0x22, 0x14, 0x31).
+     * SID 0x00 is reserved as "empty request" by uds_process_request
+     * and produces no response at all — we need a real unknown SID. */
+    uint8_t req[4] = { 0xAAU, 0x00U, 0x00U, 0x00U };
+    can_rx_process(&state.can, CAN_ID_UDS_REQUEST, req, CAN_DLC_UDS_REQUEST);
+
+    raw = make_raw(100.0F, 0.0F, 0.0F);
+    aeb_core_step(&state, &raw);
+
+    const tx_record_t *resp = find_tx(CAN_ID_UDS_RESPONSE);
+    TEST_ASSERT(resp != NULL,
+        "negative response frame 0x7E8 transmitted on unknown SID");
+    if (resp != NULL)
+    {
+        TEST_ASSERT(resp->data[0] == 0x7FU,
+            "negative response SID byte is 0x7F");
+        TEST_ASSERT(resp->data[2] == 0x11U,
+            "NRC 0x11 (Service Not Supported) on unknown SID");
+    }
+}
+
+static void test_uds_negative_response_unknown_did(void)
+{
+    aeb_core_state_t state;
+    raw_sensor_input_t raw;
+
+    printf("\n[TEST] UDS negative response — unknown DID\n");
+    (void)aeb_core_init(&state);
+    can_hal_test_reset();
+
+    {
+        uint8_t enable_frame[8] = {0};
+        can_pack_signal(enable_frame, 16, 1, 1U);
+        can_rx_process(&state.can, 0x101U, enable_frame, 8U);
+    }
+    inject_can_frames(&state, 100.0F, 0.0F);
+
+    /* ReadDID with a DID outside the supported set (0xF100, 0xF101, 0xF102). */
+    uint8_t req[4] = { 0x22U, 0xFFU, 0xFFU, 0x00U };
+    can_rx_process(&state.can, CAN_ID_UDS_REQUEST, req, CAN_DLC_UDS_REQUEST);
+
+    raw = make_raw(100.0F, 0.0F, 0.0F);
+    aeb_core_step(&state, &raw);
+
+    const tx_record_t *resp = find_tx(CAN_ID_UDS_RESPONSE);
+    TEST_ASSERT(resp != NULL,
+        "negative response frame 0x7E8 transmitted on unknown DID");
+    if (resp != NULL)
+    {
+        TEST_ASSERT(resp->data[0] == 0x7FU,
+            "negative response SID byte is 0x7F");
+        TEST_ASSERT(resp->data[2] == 0x31U,
+            "NRC 0x31 (Request Out Of Range) on unknown DID");
+    }
+}
+
 static void test_speed_out_of_range(void)
 {
     aeb_core_state_t state;
@@ -309,6 +386,8 @@ int main(void)
     test_sensor_fault_to_off();
     test_speed_out_of_range();
     test_uds_request_response_roundtrip();
+    test_uds_negative_response_unknown_sid();
+    test_uds_negative_response_unknown_did();
 
     printf("\n========================================\n");
     printf("  Results: %d/%d passed, %d failed\n",


### PR DESCRIPTION
# Summary
- Wire UDS server into the AEB 10 ms core cycle so requests on CAN ID 0x7DF produce a response on 0x7E8 within the same cycle.
- Add `CAN_ID_UDS_REQUEST` / `CAN_ID_UDS_RESPONSE` filters and DBC layout decoding in `aeb_can`.
- Expose `uds_request_t` + `uds_request_pending` on `can_rx_data_t` plus two helpers: `can_tx_uds_response()`, `can_ack_uds_request()`.
- Insert step 10 in `aeb_core_step` (between UDS fault monitoring and CAN TX) that invokes `uds_process_request()` with live FSM/PID/TTC outputs, transmits the response, and clears the pending flag.
- Lift the TX capture struct into `stubs/can_hal_test.h` so tests can inspect transmitted frame bytes with a single definition of `tx_record_t`.
- Add 3 unit tests (`test_can`) and 1 end-to-end test (`test_integration`) covering decode, encode, ack, and full round-trip.
- Scope is the ISO 14229 functional broadcast (0x7DF); physical addressing on 0x7E0 is deferred.

# Related Issue
Closes #96

# Change Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [x] CAN Interface
- [x] UDS Diagnostics
- [x] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-UDS-005 — UDS request/response via CAN within one cycle (CAN path previously unwired; now complete end-to-end).
- FR-CAN-002 — RX filter list extended to include 0x7DF.
- FR-CAN-003 — DBC signal encoding applied to `UDS_Request` (0x7DF) and `UDS_Response` (0x7E8).

## Non-Functional Requirements
- NFR-PERF-001 — request is serviced inside the same 10 ms cycle; no extra context switches.
- NFR-POR-003 — module portability preserved (`can_hal_test.h` is test-only; production code path unchanged).

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes
- [ ] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence

Commands executed:
```
make test
```

Per-suite results (188/188 passed; up from 167/167 on development):
```
test_smoke:        14/14
test_can:          51/51  (+3 UDS: rx_uds_request, tx_uds_response, uds_request_ack)
test_perception:   25/25
test_decision:      9/9
test_pid:          19/19
test_alert:        27/27
test_uds:          23/23
test_integration:  20/20  (+1 UDS round-trip)
```

Build flags: `-Wall -Wextra -Wpedantic -std=c99 -O2` — zero warnings.

Affected scenarios: none of the CCRs / CCRm / CCRb scenarios change behavior. The new step 10 is a no-op when `uds_request_pending == 0`, which is the case for every existing integration scenario.

# Reviewer Notes

- Step ordering in `aeb_core_step` — UDS request service runs **after** fault monitoring (so DTC queries reflect the state the monitor just observed) and **before** CAN TX (so there is no intra-cycle lag on the response).
- `tx_record_t` was extracted from `stubs/can_hal.c` into `stubs/can_hal_test.h`. It is included only by the stub and by tests, so it does not leak into production builds.
- On-wire layout for UDS frames is a 1:1 byte map (`uds_request_t` = 4 bytes, `uds_response_t` = 8 bytes), matching `aeb_system.dbc`. No bit-packing helpers are needed.
- RX path sets `uds_request_pending = 1U` on a valid 0x7DF frame; the core cycle guarantees exactly one service-then-ack per request.

# Risks / Open Points

- **Scope**: only 0x7DF (functional) is filtered and decoded. 0x7E0 (physical, per-ECU) is deferred until a real tool requires it.
- **No queue**: if two 0x7DF requests arrive in the same 10 ms window, the second overwrites the first before it is serviced. This matches the SRS (one cycle = one request) but is worth flagging for a future stress test.
- **MISRA**: `make misra-decision` / `make misra-uds` are unaffected; a system-wide MISRA sweep for the new code is planned under Deliverable 4 (separate task, not in this PR).
- **Follow-ups**: the SIL "UDS Diagnostic" scenario (Python TCP UDS client + FastAPI endpoints + dashboard panel) lands on `feat/sil-gazebo-docker` after this PR merges.
