### PR TITLE
fix(can): guard encode_unsigned against NaN / +-Inf in float-to-uint32 cast

### DIFF
--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -78,27 +78,10 @@ static uint32_t encode_unsigned(float32_t physical,
                                 float32_t factor,
                                 float32_t offset)
 {
-    /* Robust float-to-uint32 conversion for DBC signal packing.
-     *
-     * IEEE 754 NaN compares false to everything, so a naive
-     * `raw_f < 0.0F` guard lets NaN fall through to
-     * `(uint32_t)(raw_f + 0.5F)` — undefined behaviour per C11
-     * §6.3.1.4. ±Inf and very large finite floats hit the same UB.
-     * Division by zero in (physical - offset) / factor also produces
-     * ±Inf → UB.
-     *
-     * This function guarantees deterministic output for any float
-     * input: finite in-range values encode normally; non-finite or
-     * out-of-range values saturate to 0 (negative / NaN) or
-     * UINT32_MAX (positive overflow) so the resulting CAN frame is
-     * always well-defined — never UB, never toolchain-dependent.
-     *
-     * Upper bound 4294967040.0F (= UINT32_MAX - 255) is the largest
-     * float32 value that, after +0.5F rounding, still casts into
-     * uint32 without overflow. Values above that saturate.
-     *
-     * Single exit point (MISRA C:2012 Rule 15.5).
-     * Surfaced by V&V cross-validation on PR #89 (Bug 1). */
+    /* NaN / ±Inf / overflow on the float→uint32 cast is UB per C11
+     * §6.3.1.4; saturate at 4294967040.0F (UINT32_MAX − 255, largest
+     * float32 that rounds cleanly into range). See commit body for
+     * full rationale. */
     uint32_t raw = 0U;
 
     if (isfinite(physical))

--- a/src/communication/aeb_can.c
+++ b/src/communication/aeb_can.c
@@ -14,6 +14,7 @@
 
 #include "aeb_can.h"
 #include "can_hal.h"   /* Zephyr CAN HAL stub / real driver */
+#include <math.h>      /* isfinite() — NaN / ±Inf guard on encode_unsigned */
 #include <string.h>
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -77,16 +78,44 @@ static uint32_t encode_unsigned(float32_t physical,
                                 float32_t factor,
                                 float32_t offset)
 {
-    float32_t raw_f = (physical - offset) / factor;
-    uint32_t  raw   = 0U;
+    /* Robust float-to-uint32 conversion for DBC signal packing.
+     *
+     * IEEE 754 NaN compares false to everything, so a naive
+     * `raw_f < 0.0F` guard lets NaN fall through to
+     * `(uint32_t)(raw_f + 0.5F)` — undefined behaviour per C11
+     * §6.3.1.4. ±Inf and very large finite floats hit the same UB.
+     * Division by zero in (physical - offset) / factor also produces
+     * ±Inf → UB.
+     *
+     * This function guarantees deterministic output for any float
+     * input: finite in-range values encode normally; non-finite or
+     * out-of-range values saturate to 0 (negative / NaN) or
+     * UINT32_MAX (positive overflow) so the resulting CAN frame is
+     * always well-defined — never UB, never toolchain-dependent.
+     *
+     * Upper bound 4294967040.0F (= UINT32_MAX - 255) is the largest
+     * float32 value that, after +0.5F rounding, still casts into
+     * uint32 without overflow. Values above that saturate.
+     *
+     * Single exit point (MISRA C:2012 Rule 15.5).
+     * Surfaced by V&V cross-validation on PR #89 (Bug 1). */
+    uint32_t raw = 0U;
 
-    if (raw_f < 0.0F)
+    if (isfinite(physical))
     {
-        raw = 0U;
-    }
-    else
-    {
-        raw = (uint32_t)(raw_f + 0.5F);  /* round to nearest */
+        const float32_t raw_f = (physical - offset) / factor;
+
+        if (isfinite(raw_f) && (raw_f >= 0.0F))
+        {
+            if (raw_f > 4294967040.0F)
+            {
+                raw = UINT32_MAX;           /* saturate at cast ceiling */
+            }
+            else
+            {
+                raw = (uint32_t)(raw_f + 0.5F);  /* round to nearest */
+            }
+        }
     }
 
     return raw;

--- a/tests/test_can.c
+++ b/tests/test_can.c
@@ -313,6 +313,96 @@ TEST(test_tx_fsm_period)
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
+ *  TESTS: encode_unsigned robustness — exercised through can_tx_brake_cmd,
+ *  which feeds pid_out->brake_bar into encode_unsigned for the 15-bit
+ *  BrakePressure field at bits 1..15. Lock the post-fix contract so any
+ *  future regression at the cast boundary is caught at unit level instead
+ *  of waiting for fault-injection.
+ *
+ *  The legitimate-input path is already covered by test_tx_brake_cmd
+ *  above; these four tests cover the four UB-inducing input classes the
+ *  cross-validation report flagged on PR #89.
+ *
+ *  NaN / ±Inf -> encode_unsigned returns 0 -> BrakePressure raw == 0.
+ *  Finite > UINT32_MAX ceiling -> saturates to UINT32_MAX -> 15-bit
+ *  field masked to 0x7FFF (all-ones).
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+/** Helper — extract the 15-bit BrakePressure field from a captured frame. */
+static uint32_t extract_brake_pressure(const tx_record_t *tx)
+{
+    return can_unpack_signal(tx->data, 1U, 15U);
+}
+
+TEST(test_tx_brake_cmd_nan_brake_bar)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    pid_output_t pid = { .brake_pct = 0.0F, .brake_bar = NAN };
+    fsm_output_t fsm = { .fsm_state = (uint8_t)FSM_BRAKE_L1 };
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+    ASSERT_EQ(can_hal_test_get_tx_count(), 1U);
+
+    const tx_record_t *tx = can_hal_test_get_tx(0U);
+    ASSERT_EQ(extract_brake_pressure(tx), 0U);
+}
+
+TEST(test_tx_brake_cmd_pos_inf_brake_bar)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    pid_output_t pid = { .brake_pct = 0.0F, .brake_bar = INFINITY };
+    fsm_output_t fsm = { .fsm_state = (uint8_t)FSM_BRAKE_L1 };
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+
+    const tx_record_t *tx = can_hal_test_get_tx(0U);
+    ASSERT_EQ(extract_brake_pressure(tx), 0U);
+}
+
+TEST(test_tx_brake_cmd_neg_inf_brake_bar)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    pid_output_t pid = { .brake_pct = 0.0F, .brake_bar = -INFINITY };
+    fsm_output_t fsm = { .fsm_state = (uint8_t)FSM_BRAKE_L1 };
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+
+    const tx_record_t *tx = can_hal_test_get_tx(0U);
+    ASSERT_EQ(extract_brake_pressure(tx), 0U);
+}
+
+TEST(test_tx_brake_cmd_overflow_brake_bar)
+{
+    can_state_t state;
+    can_hal_test_reset();
+    (void)can_init(&state);
+
+    /* 1e20 / 0.1 = 1e21 — far above the 4294967040.0F cast ceiling.
+     * encode_unsigned must saturate at UINT32_MAX; can_pack_signal
+     * then masks to the 15-bit field width = 0x7FFF (all-ones). */
+    pid_output_t pid = { .brake_pct = 0.0F, .brake_bar = 1.0e20F };
+    fsm_output_t fsm = { .fsm_state = (uint8_t)FSM_BRAKE_L1 };
+
+    int32_t rc = can_tx_brake_cmd(&state, &pid, &fsm);
+    ASSERT_EQ(rc, CAN_OK);
+
+    const tx_record_t *tx = can_hal_test_get_tx(0U);
+    ASSERT_EQ(extract_brake_pressure(tx), 0x7FFFU);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
  *  TEST: TX failure handling
  * ═══════════════════════════════════════════════════════════════════════ */
 TEST(test_tx_send_failure)
@@ -454,6 +544,10 @@ int main(void)
     RUN(test_rx_timeout);
     RUN(test_rx_timeout_reset_on_valid_frame);
     RUN(test_tx_brake_cmd);
+    RUN(test_tx_brake_cmd_nan_brake_bar);
+    RUN(test_tx_brake_cmd_pos_inf_brake_bar);
+    RUN(test_tx_brake_cmd_neg_inf_brake_bar);
+    RUN(test_tx_brake_cmd_overflow_brake_bar);
     RUN(test_tx_fsm_period);
     RUN(test_tx_send_failure);
     RUN(test_rx_uds_request);


### PR DESCRIPTION
# Summary
- Guard `encode_unsigned` in `src/communication/aeb_can.c` against NaN / plus-minus-Inf / out-of-range float inputs that caused Undefined Behaviour on the `(uint32_t)(raw_f + 0.5F)` cast (C11 section 6.3.1.4).
- Replace the fail-safe-by-coincidence pattern (`raw_f < 0.0F` does not catch NaN because NaN comparisons are all false) with explicit `isfinite()` checks on input and post-arithmetic, plus upper-bound saturation at UINT32_MAX.
- No behavioural change for legitimate inputs: all 195/195 nominal tests stay green.

# Related Issue
Closes #101

Surfaces the fix deferred by PR #89 consolidated report (Bug 1). Same defensive pattern adopted by #94 (UDS float-to-uint16 validation) and #100 (PID `isfinite` guards).

# Change Type
- [ ] feat
- [x] fix
- [ ] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [x] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-CAN-003 (DBC signal encoding) -- now robust to invalid float inputs.

## Non-Functional Requirements
- NFR-SAF-ROB (robustness against invalid inputs).
- NFR-COD-001 (MISRA C:2012 -- Rule 15.5 single exit point preserved).

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [ ] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes (`make build` -- zero warnings, `-Wall -Wextra -Wpedantic -std=c99 -O2`)
- [x] Automated tests pass (`make test` -- 195/195 across all 8 suites, no regression)
- [ ] CI passes (automatic once opened)
- [x] Traceability updated (`Closes #101`, referenced in commit message)
- [x] Safety-relevant impact assessed (see Evidence)
- [ ] Documentation updated

## Evidence

### The bug (as flagged by the V&V cross-validation)

```c
/* before — raw_f < 0.0F lets NaN fall through, cast is UB */
float32_t raw_f = (physical - offset) / factor;
if (raw_f < 0.0F) {
    raw = 0U;
} else {
    raw = (uint32_t)(raw_f + 0.5F);   /* UB on NaN, +-Inf, huge finite */
}
```

Four UB-inducing input classes:
1. NaN (upstream `clamp_f32` silently passes NaN through because NaN comparisons are false).
2. plus-minus Inf (sensor saturation, arithmetic overflow).
3. Finite floats greater than UINT32_MAX.
4. `factor = 0` producing Inf via division.

### The fix

```c
uint32_t raw = 0U;

if (isfinite(physical)) {
    const float32_t raw_f = (physical - offset) / factor;

    if (isfinite(raw_f) && (raw_f >= 0.0F)) {
        if (raw_f > 4294967040.0F) {
            raw = UINT32_MAX;              /* saturate */
        } else {
            raw = (uint32_t)(raw_f + 0.5F);
        }
    }
}

return raw;   /* single exit */
```

Output contract:
- Finite in-range input -> identical to the pre-fix value (nominal suite unchanged).
- NaN / plus-minus Inf -> 0 (deterministic).
- Negative finite -> 0 (legacy behaviour preserved).
- Finite greater than UINT32_MAX ceiling -> UINT32_MAX (deterministic saturation).
- `factor = 0` -> isfinite(raw_f) catches the Inf -> 0.

### Test results

```
test_smoke:        14/14
test_can:          52/52
test_perception:   25/25
test_decision:      9/9
test_pid:          19/19
test_alert:        27/27
test_uds:          23/23
test_integration:  26/26
---
total:            195/195   (no regression)
```

### Local UBSan on Windows/MinGW

The MinGW 15 toolchain on the author's Windows host does not ship `libubsan`, so UBSan verification was not runnable locally. The fix logic is straightforward (finite-guard + saturate before cast) and the CI Ubuntu 24.04 runner exercises `-fsanitize=undefined` via `make memory-uds` / `make memory-pid-alert` / `make memory-decision`. Expect the `encode_unsigned` line to stop appearing in the fault-suite UBSan log once PR #100 (PID robustness, which exercises the corrupted `brake_bar` path) and this PR both land.

# Reviewer Notes

- Defence-in-depth only at `encode_unsigned` -- no changes to `can_tx_brake_cmd` / `can_tx_fsm_state` callers. Fixing at the boundary is the correct layer: every float-input DBC encode path goes through this one function.
- `UINT32_MAX` comes from `<stdint.h>` via `aeb_types.h` -- no new header dependency.
- `4294967040.0F` is `UINT32_MAX - 255`, the largest float32 that still rounds cleanly into uint32 (one-line comment in the source explains this).
- Pattern is deliberately consistent with #94 (UDS) and #100 (PID) so all three modules use the same style of float-input hardening.

# Risks / Open Points

- UBSan log change won't be visible until PR #100 (PID robustness) merges and `fault-pid-alert` exercises the corrupted `brake_bar` path through the encoder. This PR is the receiver-side fix; PR #100 produced the sender-side fix.
- `can_tx_fsm_state` calls `encode_unsigned(ttc_thresh, 0.1F, 0.0F)` with `ttc_thresh` derived from a `switch` with hardcoded floats (`TTC_WARNING`, `TTC_BRAKE_L1`, ...) -- those paths were already safe by construction. The fix is here for defence-in-depth.
- MISRA: `isfinite()` is standard C99 but its expansion can produce a comparison that cppcheck sometimes flags as 10.1 (implicit type conversion). If the gate trips, an `(x != 0)` wrap on the `isfinite()` call is the standard remediation -- will address in the review cycle if needed.