### PR TITLE
ci(vv-uds): promote fault-uds gate to blocking after fix/uds-robustness

### DIFF
--- a/.github/workflows/vv-uds.yml
+++ b/.github/workflows/vv-uds.yml
@@ -3,11 +3,11 @@ name: UDS V&V
 # Runs the ASIL-D V&V stack scoped to the UDS module.
 #
 # Triggers only on paths that can affect UDS behaviour. On PRs to
-# development/main, the blocking gates (MC/DC, memory safety, MISRA) must
-# pass; fault-uds is intentionally non-blocking until the three
-# robustness bugs documented in reports/vv_uds/fault_injection/run.log
-# are patched on fix/uds-robustness. After that PR lands, flip
-# `continue-on-error` on the fault-injection step to `false`.
+# development/main, four blocking gates must pass: MC/DC coverage,
+# dynamic memory safety, MISRA C:2012 conformance, and fault injection.
+# The fault-injection gate became blocking after PR #94 (fix/uds-robustness)
+# patched the three robustness bugs surfaced by the V&V; any new fault
+# regression is now treated as a CI failure.
 #
 # Reports are published in two layers:
 #   1. Workflow Artifacts on every run (PR or push), retention 30 days.
@@ -147,10 +147,12 @@ jobs:
             exit 1
           fi
 
-      # ─── Non-blocking (reports-only) until fix/uds-robustness lands ───────
-      # Flip `continue-on-error` to `false` after fix/uds-robustness merges.
-      - name: Fault injection (non-blocking until bugs patched)
-        continue-on-error: true
+      # ─── Blocking gate 4: fault injection (18/18 required) ────────────────
+      # Promoted to blocking after PR #94 (fix/uds-robustness) patched the
+      # three robustness bugs. Any new fault-injection regression is now
+      # treated as a CI failure — this gate guards against the exact
+      # classes of defects that V&V cross-validation originally surfaced.
+      - name: Fault injection
         run: make fault-uds
 
       # ─── Generate navigable HTML reports ──────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -179,12 +179,6 @@ fault-uds:
 	@$(VV_REPORT_DIR)/fault_injection/test_uds_fault > $(VV_REPORT_DIR)/fault_injection/run.log 2>&1; \
 		rc=$$?; \
 		cat $(VV_REPORT_DIR)/fault_injection/run.log; \
-		echo ""; \
-		if [ "$$rc" = "0" ]; then \
-			echo "(all fault assertions PASS — time to flip continue-on-error to false in vv-uds.yml)"; \
-		else \
-			echo "(non-zero exit expected while bugs are pending patch)"; \
-		fi; \
 		exit $$rc
 
 memory-uds:


### PR DESCRIPTION
# Summary
- Remove `continue-on-error: true` from the fault-injection step of `vv-uds.yml`. PR #94 merged the three robustness fixes that were keeping the suite at 11/18 PASS; local `make fault-uds` now reports 18/18 PASS so the gate can be blocking.
- Rename the step from "Fault injection (non-blocking until bugs patched)" to just "Fault injection" and rewrite the workflow top comment to reflect the new four-gate policy (MC/DC + memory + MISRA + fault, all blocking).
- Simplify `Makefile`'s `fault-uds` recipe: drop the now-stale conditional echo (the PASS message pointed at the flip-to-blocking TODO done in this PR; the FAIL message said "non-zero exit expected while bugs are pending patch" which becomes misleading once bugs ARE patched). Recipe still captures the log and propagates the real exit code.

# Related Issue
Closes #88 for the UDS scope — the follow-up ticket about unifying the fault-module echo anti-pattern. This PR lands the UDS half; `fault-decision` and `fault-pid-alert` follow in separate PRs as their respective `fix/*-robustness` branches merge.

# Change Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] test
- [x] ci
- [x] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [x] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted
## Functional Requirements
- FR-UDS-002 (DTC latching), FR-UDS-005 (request / response) — the fault-injection gate now enforces these against regression.

## Non-Functional Requirements
- NFR-SAF-ROB — fault-injection coverage is now a blocking requirement, not reports-only.

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [ ] C source code
- [ ] Tests
- [x] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes (`make build` — zero warnings)
- [x] Automated tests pass (`make test` — 195/195 across 8 suites)
- [ ] CI passes (automatic once opened)
- [x] Traceability updated (`Closes #88` — UDS scope)
- [x] Safety-relevant impact assessed (see Evidence)
- [ ] Documentation updated

## Evidence

### `make fault-uds` output on this branch (development tip + this change)

```
======================================
  Assertions: 18 run  18 passed  0 failed
======================================
```

(Trimmed to the summary; the full log is reproducible with `make fault-uds` on the checked-out branch.)

### Before/after behaviour

| Scenario | Before (reports-only) | After (blocking) |
|---|---|---|
| Fault suite 18/18 PASS | CI green | CI green |
| Fault suite regression (say 17/18) | CI green, reports-only | CI red, gate fails |
| New bug surfaces | CI green | CI red — forces a `fix/*` PR before merge |

### Full test suite

```
test_smoke:        14/14
test_can:          52/52
test_perception:   25/25
test_decision:      9/9
test_pid:          19/19
test_alert:        27/27
test_uds:          23/23
test_integration:  26/26
---
total:            195/195   (no regression)
```

# Reviewer Notes

- The PR is intentionally small and scoped: two files, strictly the flip and the stale-message cleanup. Nothing in `aeb_uds.c`, `test_uds*.c`, or any module source. The promotion is mechanical.
- The four-gate policy in the workflow comment now reads: "MC/DC coverage, dynamic memory safety, MISRA C:2012 conformance, and fault injection" — keeping it future-proof for when `fault-decision` and `fault-pid-alert` also flip.
- `fault-uds` recipe is now the template I'd like `fault-decision` / `fault-pid-alert` to follow once their `fix/*-robustness` PRs land — captures the log, prints it, exits with the real code, no stale conditional echo. That consolidation is tracked in #88.

# Risks / Open Points

- If a hidden upstream regression re-introduces a fault failure, the PR that regresses it fails CI at this gate instead of being reports-only. That is the intended behaviour but worth flagging so nobody is surprised.
- `fault-decision` on `development` still has the old `tee`-based recipe that masks the exit code. That is out of scope here (different module) and tracked in #88 for a follow-up PR.