### PR TITLE
fix(decision): address ASIL-D robustness and MISRA findings from V&V …

### DIFF
--- a/src/decision/aeb_fsm.c
+++ b/src/decision/aeb_fsm.c
@@ -9,6 +9,7 @@
 #include "aeb_fsm.h"
 #include "aeb_config.h"
 #include "aeb_types.h"
+#include <math.h>    /* isfinite() — Bug #3 guard in fsm_step entry */
 #include <stddef.h>
 
 /* Steering override threshold (degrees) - FR-FSM-006 */
@@ -160,19 +161,48 @@ void fsm_step(float32_t delta_t_s,
     fsm_state_e new_state;
     uint8_t driver_override = 0U;
     uint8_t speed_out_of_range = 0U;
+    uint8_t aeb_enabled_norm;
 
-    /* Defensive checks */
-    if ((delta_t_s <= 0.0f) || (perception == NULL) ||
-        (driver == NULL) || (ttc_in == NULL) || (fsm_out == NULL))
+    /* Defensive checks.
+     * Bug #3: reject non-finite delta_t_s. IEEE 754 comparisons with NaN
+     * are always false, so (delta_t_s <= 0.0f) alone lets NaN through.
+     * A NaN delta_t would poison the warn_timer / debounce_timer
+     * accumulators on the first `+= delta_t_s`, silently breaking
+     * debounce, escalation, and POST_BRAKE timeout logic. */
+    if ((!isfinite(delta_t_s)) || (delta_t_s <= 0.0f) ||
+        (perception == NULL) || (driver == NULL) ||
+        (ttc_in == NULL) || (fsm_out == NULL))
     {
         return;
     }
 
+    /* Bug #2 SEU hardening: normalise driver->aeb_enabled to a strict
+     * Boolean at entry. A bit-flip that turns 1U into (say) 0xAA would
+     * otherwise make (aeb_enabled == 0U) false and leave the FSM running
+     * on corrupted state. Any non-zero bit pattern is treated as enabled;
+     * any zero is treated as disabled. */
+    aeb_enabled_norm = (driver->aeb_enabled != 0U) ? 1U : 0U;
+
     current_state = (fsm_state_e)fsm_out->fsm_state;
+
+    /* Bug #4 SEU hardening: normalise out-of-enum fsm_state to the
+     * fail-safe FSM_STANDBY. A bit-flip in RAM could corrupt the
+     * persisted fsm_state byte (e.g. 1 -> 42), which would then be
+     * inherited by new_state at the top of the transition logic and,
+     * on iterations where desired_state resolves to STANDBY, would be
+     * written back unchanged into fsm_out->fsm_state — and broadcast
+     * via CAN/UDS to actuators and displays. STANDBY is the conservative
+     * choice: zero braking demand, no alert. */
+    if ((uint8_t)current_state > (uint8_t)FSM_POST_BRAKE)
+    {
+        current_state = FSM_STANDBY;
+        fsm_out->fsm_state = (uint8_t)FSM_STANDBY;
+    }
+
     desired_state = evaluate_desired_state(perception, ttc_in);
 
     /* ===== PRIORITY 1: Fault and Safety ===== */
-    if ((perception->fault_flag != 0U) || (driver->aeb_enabled == 0U))
+    if ((perception->fault_flag != 0U) || (aeb_enabled_norm == 0U))
     {
         fsm_out->fsm_state = (uint8_t)FSM_OFF;
         fsm_out->brake_active = 0U;
@@ -187,9 +217,12 @@ void fsm_step(float32_t delta_t_s,
     }
 
     /* ===== PRIORITY 2: Driver Override ===== */
-    driver_override = (driver->brake_pedal != 0U) ||
-                      (driver->steering_angle > STEERING_OVERRIDE_DEG) ||
-                      (driver->steering_angle < -STEERING_OVERRIDE_DEG);
+    /* MISRA C:2012 Rule 10.3: the Boolean expression on the right-hand
+     * side must be explicitly cast to the uint8_t essential type of
+     * the lvalue. */
+    driver_override = (uint8_t)((driver->brake_pedal != 0U) ||
+                                (driver->steering_angle > STEERING_OVERRIDE_DEG) ||
+                                (driver->steering_angle < -STEERING_OVERRIDE_DEG));
 
     if ((driver_override != 0U) && (current_state != FSM_POST_BRAKE))
     {
@@ -205,8 +238,9 @@ void fsm_step(float32_t delta_t_s,
     }
 
     /* ===== PRIORITY 3: Speed Range Validation ===== */
-    speed_out_of_range = (perception->v_ego < V_EGO_MIN) ||
-                         (perception->v_ego > V_EGO_MAX);
+    /* MISRA C:2012 Rule 10.3: explicit cast to uint8_t essential type. */
+    speed_out_of_range = (uint8_t)((perception->v_ego < V_EGO_MIN) ||
+                                   (perception->v_ego > V_EGO_MAX));
 
     if (speed_out_of_range != 0U)
     {
@@ -263,17 +297,25 @@ void fsm_step(float32_t delta_t_s,
                     m_fsm_mem.debounce_timer_s = 0.0f;
                 }
             }
+            else
+            {
+                /* MISRA C:2012 Rule 15.7: terminal else clause.
+                 * Reached when desired_state is WARNING (same as current)
+                 * — no state change, no timer reset. */
+            }
             break;
 
         case FSM_BRAKE_L1:
         case FSM_BRAKE_L2:
         case FSM_BRAKE_L3:
-            if (perception->v_ego < 0.01f)
-            {
-                new_state = FSM_POST_BRAKE;
-                m_fsm_mem.post_brake_timer_s = 0.0f;
-            }
-            else if (desired_state > current_state)
+            /* D3: the former `if (perception->v_ego < 0.01f)` branch
+             * that transitioned to FSM_POST_BRAKE was unreachable — it
+             * is dominated by the Priority-3 speed guard above, which
+             * fires on v_ego < V_EGO_MIN = 2.78 m/s before control
+             * ever reaches this switch. Removed per V&V report Sec. 7.5
+             * desvio D3 (MISRA C:2012 Rule 2.1). Low-speed exit into
+             * POST_BRAKE is now handled exclusively by the speed guard. */
+            if (desired_state > current_state)
             {
                 /* Escalation: immediate */
                 new_state = desired_state;
@@ -310,6 +352,12 @@ void fsm_step(float32_t delta_t_s,
             {
                 /* Force pass through WARNING (FR-DEC-011) */
                 new_state = FSM_WARNING;
+            }
+            else
+            {
+                /* MISRA C:2012 Rule 15.7: terminal else clause.
+                 * Reached when desired_state is STANDBY or POST_BRAKE
+                 * — no transition, stay in STANDBY. */
             }
             break;
     }

--- a/src/decision/aeb_ttc.c
+++ b/src/decision/aeb_ttc.c
@@ -8,6 +8,7 @@
 
 #include "aeb_ttc.h"
 #include "aeb_config.h"
+#include <math.h>    /* isfinite() — Bug #1 guard in d_brake_calc */
 #include <stddef.h>
 
 float32_t ttc_calc(float32_t distance, float32_t v_rel)
@@ -22,14 +23,16 @@ float32_t ttc_calc(float32_t distance, float32_t v_rel)
         {
             ttc_result = distance / v_rel;
 
-            /* Clamp to [0, TTC_MAX] seconds per SRS */
+            /* Clamp to [0, TTC_MAX] seconds per SRS.
+             * D1: only the upper bound is reachable — the guard above
+             * ensures distance > 0 AND v_rel > V_REL_MIN > 0, so the
+             * quotient is strictly positive. The defensive
+             * `else if (ttc_result < 0.0f)` branch was unreachable
+             * (MISRA C:2012 Rule 2.1) and was removed as catalogued in
+             * the V&V report Sec. 7.5 desvio D1. */
             if (ttc_result > TTC_MAX)
             {
                 ttc_result = TTC_MAX;
-            }
-            else if (ttc_result < 0.0f)
-            {
-                ttc_result = 0.0f;
             }
         }
     }
@@ -41,11 +44,24 @@ float32_t d_brake_calc(float32_t v_ego)
 {
     float32_t d_brake;
 
+    /* Bug #1 fail-safe gate: reject non-finite input (NaN, +Inf, -Inf).
+     * IEEE 754 comparisons with NaN are false, so `d_brake < 0.0f` below
+     * cannot be relied on to catch this. */
+    if (!isfinite(v_ego))
+    {
+        return 0.0f;
+    }
+
     /* FR-DEC-002: d_brake = v² / (2 * a) with a = DECEL_L3 = 6.0 m/s² */
     d_brake = (v_ego * v_ego) / (2.0f * DECEL_L3);
 
-    /* Physical lower bound */
-    if (d_brake < 0.0f)
+    /* Overflow guard: a very large but finite v_ego (e.g. FLT_MAX)
+     * squares to +Inf, which would slip past the isfinite() gate above.
+     * The original `d_brake < 0.0f` clamp that used to be here is
+     * unreachable (IEEE 754: v*v >= 0 for all finite v, including
+     * subnormals) and was removed per V&V report Sec. 7.5 desvio D2
+     * (MISRA C:2012 Rule 2.1). */
+    if (!isfinite(d_brake))
     {
         d_brake = 0.0f;
     }


### PR DESCRIPTION
Applies the four robustness patches proposed by the Decision V&V cross-validation report (`reports/vv_decision/Relatorio_Consolidado_VV_Decision.pdf`), plus the catalogued dead-code removals and required MISRA findings. Parallels `fix/uds-robustness` (#94) and `fix/can-encode-robustness` (#102).

Four bugs fixed (all were surfaced by `test_decision_fault.c` during independent cross-validation):
- **Bug 1** — `d_brake_calc` propagating NaN/±Inf (Sec. 7.1)
- **Bug 2** — `driver->aeb_enabled` SEU sensitivity (Sec. 7.2)
- **Bug 3** — `fsm_step` entry guard bypass via `delta_t_s = NaN` (Sec. 7.3)
- **Bug 4** — corrupted `fsm_state` propagation via `new_state` (Sec. 7.4)

Three justified MISRA Rule 2.1 findings removed: unreachable defensive branches in `ttc_calc`, `d_brake_calc`, and the FSM_BRAKE case of `fsm_step` (Sec. 7.5 desvios D1/D2/D3). The fourth deviation (D4, NULL guard in `fsm_init`) is kept — MISRA Directive 4.7 mandated.

Four required MISRA findings addressed (Sec. 6.2): 10.3 ×2 (explicit cast on Boolean→uint8_t) and 15.7 ×2 (terminal else on if/else-if chains). The fifth original finding (15.7 at `aeb_ttc.c:33`) is closed by the D1 removal.

Follows ISO 26262-6 §5.4.8 — patch authored by the module owner after independent cross-validation.

# Summary

- Four ASIL-D robustness patches in `aeb_ttc.c` and `aeb_fsm.c`, each targeted at the specific fail-safe violation surfaced by the V&V fault-injection suite. Returns 0.0f / STANDBY are the conservative fail-safe choices per project convention.
- Three unreachable defensive branches removed (Rule 2.1); lifts expected cross-validation coverage from 97.7/96.8/96.6% (stmt/branch/MC/DC) to ~100/99.2/99.1%.
- Four MISRA required findings addressed (10.3 ×2, 15.7 ×2) — explicit casts and terminal else clauses; no behavioural change.
- `<math.h>` added to both `aeb_ttc.c` and `aeb_fsm.c` for `isfinite()`.
- Nominal test suite `test_decision` continues to pass 9/9 — none of the patches changes the happy path.
- All patches were proposed verbatim in the V&V report §7 with code samples; this PR implements them.

# Related Issue

Closes #64 (Bug 1 — TTC: guard `d_brake_calc` against non-finite `v_ego`).
Closes #65 (Bug 2 — FSM: normalize `driver->aeb_enabled` before comparison, SEU protection).
Closes #66 (Bug 3 — FSM: gate `fsm_step` `delta_t_s` against NaN).
Closes #67 (Bug 4 — FSM: normalize out-of-enum `fsm_state` to `FSM_STANDBY` on entry).


# Change Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected

- [ ] Perception
- [x] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [x] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

# Requirements Impacted

## Functional Requirements

- FR-DEC-001 (TTC calculation) — Bug 1 fix ensures deterministic behaviour on invalid `v_ego` input.
- FR-DEC-002 (braking distance) — Bug 1 fix hardens `d_brake_calc` against NaN/±Inf.
- FR-DEC-003 (dual-criterion braking floor) — guarded by Bug #1: the `d_brake >= distance` decision no longer operates on non-finite values.
- FR-DEC-004 / FR-DEC-010 (hysteresis, debounce) — Bug 3 fix prevents timer poisoning that would break escalation/de-escalation.
- FR-FSM-001 to FR-FSM-006 — all FSM transitions preserved; Bug 4 adds an entry-point normalisation ensuring the state read back is always inside the enum.

## Non-Functional Requirements

- NFR-SAF-ROB — primary target of this PR. All four bugs are robustness violations under invalid / corrupted input.
- NFR-PRO-MISRA — four Required findings (10.3 ×2, 15.7 ×2) addressed; three Advisory findings closed via D1/D2/D3 dead-code removal.
- NFR-COD-006 / 007 / 008 — expected coverage post-patch: stmt ~100%, branch ~99.2%, MC/DC ~99.1% (to be confirmed by re-validation).

# Artifacts Updated

- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [ ] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence

- [x] Local build passes *(zero-warning build with `-Wall -Wextra -Wpedantic -std=c99 -O2`)*
- [x] Automated tests pass *(`test_decision` nominal suite: 9/9 PASS — patches do not disturb the happy path)*
- [ ] CI passes *(pending — `vv-decision.yml` will re-run all gates on push)*
- [x] Traceability updated *(every patch is tagged in-source with the bug number and V&V report section)*
- [x] Safety-relevant impact assessed *(every fail-safe return is either STANDBY, 0.0f, or early-return — the conservative choice per ASIL-D convention used across the module)*
- [x] Documentation updated *(in-source comments explain each patch, its trigger, and the acceptance criterion from the V&V report)*

## Evidence

**Build:**
```
gcc -Wall -Wextra -Wpedantic -std=c99 -O2 -Iinclude -Istubs \
    -c src/decision/aeb_ttc.c src/decision/aeb_fsm.c
# exit 0, zero warnings
```

**Nominal suite:**
```
$ ./test_decision
--- TTC Tests (FR-DEC-001, FR-DEC-002, FR-DEC-003) ---
  PASS: TTC normal closing (5.0s)
  PASS: TTC critical (0.5s)
  PASS: TTC not closing (max 10.0s)
  PASS: Braking distance at 50 km/h
  PASS: Braking distance at zero speed

--- FSM Tests (FR-FSM-001 to FR-FSM-006) ---
  PASS: FSM initial state = STANDBY
  PASS: FSM goes to OFF on fault
  PASS: Driver override goes to STANDBY

--- Parameter Validation (SRS Table 10) ---
  PASS: Deceleration values (2/4/6 m/s² per Table 10)

RESULTS: 9 passed, 0 failed
```

**Expected fault-injection results (per V&V report Tables 4.2 and 7.x):**
- FAULT-A4, A5 (d_brake_calc NaN/Inf): PASS after Bug #1
- FAULT-B2 (d_brake_calc FLT_MAX): PASS after Bug #1
- FAULT-A6 (delta_t NaN): 2 assertions PASS after Bug #3
- FAULT-C1, C2 (fsm_state corruption): 4 assertions PASS after Bug #4
- FAULT-C3 (aeb_enabled SEU): PASS after Bug #2

Total: 11 previously-failing assertions should now pass, bringing fault-injection from 21/32 to 32/32.

Affected scenarios: CCR, CCRm, CCRb — all three UN-R152 scenarios exercise the FSM transitions and braking-floor decision. None of the patches changes the happy-path logic, so regression on these scenarios is not expected.

Back-to-back impact: none. The patches are defensive gates at entry/exit points. Control-flow is preserved on all finite, in-range, non-corrupted inputs.

# Reviewer Notes

Three points deserve focus:

1. **Fail-safe return values.** Every new gate returns either `0.0f` (`d_brake_calc`), `FSM_STANDBY` (fsm_state normalisation), or an early-return no-op (`fsm_step` entry guards). These choices follow the convention already used in the module (`ttc_calc` returns `TTC_MAX` on invalid distance, `fsm_step` priority-1 transitions to `FSM_OFF` on fault). Is this consistent with the project-wide ASIL-D convention, or should any gate use a different fail-safe?

2. **Bug #4 placement.** The SEU normalisation for `fsm_state` happens immediately after reading `fsm_out->fsm_state`, before `evaluate_desired_state()`. This ensures the rest of the tick sees a sane `current_state`. Alternative: normalise only on write. Placement-before-read also has the side-effect of correcting `fsm_out->fsm_state` externally, which is desirable (the CAN/UDS broadcast sees the corrected value). The V&V report §7.4 explicitly recommends this placement.

3. **Bug #2 limitation.** Boolean normalisation cannot distinguish a genuine 1 from a bit-flipped 0→1. Full ASIL-D protection for a Boolean field requires redundancy (flag + ~flag) at the persistent-storage layer. The V&V report calls this out explicitly and recommends opening a systemic issue — should that systemic work be tracked in this PR's description, or as a separate follow-up issue to be filed by the cross-validator?

Also worth checking: the two empty `else` clauses added for MISRA 15.7 each contain an explanatory comment stating which `desired_state` values reach that path and why no transition is warranted — the comment is the content, not a pure no-op. Reviewers should confirm the reasoning is accurate.

# Risks / Open Points

- First CI run validates these patches via `vv-decision.yml`. The MC/DC gate is expected to rise to ~99% (from 96.6%) — below 100% only because the D4 NULL guard remains justified. If the gate fires at ≥95%, the PR passes Gate 1; if it fires at ≥99%, that confirms the D1/D2/D3 removal worked end-to-end.
- The fault-injection suite `test_decision_fault.c` is part of the V&V work (PR #89-analogue for Decision, wherever that is). If that suite is not yet on `development`, the `fault-decision` gate will compile-fail in the same way `vv-can` currently does before PR #89 merges. If you see this error, the fix is the same: merge the Decision V&V PR first.
- Bug #2 mitigation is partial by design (see Reviewer Note 3). The residual risk (genuine 0/1 bit-flip that stays Boolean-valid) is documented in the V&V report §7.2 and an ECU-level issue should be opened by the cross-validator.
- Coverage figures in the PR body are *expected*, not measured — they come from the V&V report's post-patch projection. The CI run on this PR will produce the measured numbers.
- Re-validation ownership: per ISO 26262-6 §5.4.8, the cross-validator (@erycaaf ) re-runs `make vv-decision` after merge to confirm all 32/32 fault assertions pass and coverage hits the projected numbers. This is tracked in the V&V report's Tabela 8.1 actions 5–9.