### PR TITLE
fix(decision): correct aeb_enabled SEU semantics + Rule 10.5 cascade

### DIFF
--- a/src/decision/aeb_fsm.c
+++ b/src/decision/aeb_fsm.c
@@ -179,9 +179,11 @@ void fsm_step(float32_t delta_t_s,
     /* Bug #2 SEU hardening: normalise driver->aeb_enabled to a strict
      * Boolean at entry. A bit-flip that turns 1U into (say) 0xAA would
      * otherwise make (aeb_enabled == 0U) false and leave the FSM running
-     * on corrupted state. Any non-zero bit pattern is treated as enabled;
-     * any zero is treated as disabled. */
-    aeb_enabled_norm = (driver->aeb_enabled != 0U) ? 1U : 0U;
+     * on corrupted state. Strict match: only the canonical 1U bit pattern
+     * counts as enabled. Any other value (0U, SEU-corrupted bit patterns,
+     * garbage from uninitialised memory) falls safe to disabled → FSM_OFF
+     * via the Priority-1 check below. */
+    aeb_enabled_norm = (driver->aeb_enabled == 1U) ? 1U : 0U;
 
     current_state = (fsm_state_e)fsm_out->fsm_state;
 
@@ -217,12 +219,9 @@ void fsm_step(float32_t delta_t_s,
     }
 
     /* ===== PRIORITY 2: Driver Override ===== */
-    /* MISRA C:2012 Rule 10.3: the Boolean expression on the right-hand
-     * side must be explicitly cast to the uint8_t essential type of
-     * the lvalue. */
-    driver_override = (uint8_t)((driver->brake_pedal != 0U) ||
-                                (driver->steering_angle > STEERING_OVERRIDE_DEG) ||
-                                (driver->steering_angle < -STEERING_OVERRIDE_DEG));
+    driver_override = ((driver->brake_pedal != 0U) ||
+                       (driver->steering_angle > STEERING_OVERRIDE_DEG) ||
+                       (driver->steering_angle < -STEERING_OVERRIDE_DEG)) ? 1U : 0U;
 
     if ((driver_override != 0U) && (current_state != FSM_POST_BRAKE))
     {
@@ -238,9 +237,8 @@ void fsm_step(float32_t delta_t_s,
     }
 
     /* ===== PRIORITY 3: Speed Range Validation ===== */
-    /* MISRA C:2012 Rule 10.3: explicit cast to uint8_t essential type. */
-    speed_out_of_range = (uint8_t)((perception->v_ego < V_EGO_MIN) ||
-                                   (perception->v_ego > V_EGO_MAX));
+    speed_out_of_range = ((perception->v_ego < V_EGO_MIN) ||
+                          (perception->v_ego > V_EGO_MAX)) ? 1U : 0U;
 
     if (speed_out_of_range != 0U)
     {


### PR DESCRIPTION
## Summary

- Flip the `aeb_enabled` SEU normalisation in `fsm_step` from `(x != 0U) ? 1U : 0U` to `(x == 1U) ? 1U : 0U` so the V&V contract in §7.2 is honoured: only the canonical `1U` pattern counts as enabled; any other value (including SEU-corrupted `0xAA`) falls safe to disabled via the Priority-1 check.
- Refactor the two Rule 10.3 remediations from direct `(uint8_t)((expr) || (expr))` casts to the ternary pattern `((expr) || (expr)) ? 1U : 0U` at `aeb_fsm.c:223` and `:242`. Eliminates the Rule 10.5 cascade that the PR #107 cast pattern introduced, without re-opening Rule 10.3.
- Remove the now-obsolete MISRA Rule 10.3 inline comment blocks — the ternary is self-documenting and the rule-compliance trace lives in the V&V report.
- Update the Bug 2 comment block to describe the strict-match semantic so a future maintainer doesn't wonder why the comparison is `==` instead of `!=`.
- Net diff: `src/decision/aeb_fsm.c` only, 10 insertions / 12 deletions. No test, no CI, no other module touched.

## Related Issue

- Closes #108 — aeb_enabled SEU normalisation fails safe to the wrong direction
- Closes #109 — Rule 10.3 remediation cascaded into Rule 10.5

## Change Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

## AEB Areas Affected

- [ ] Perception
- [x] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [ ] Documentation only

## Requirements Impacted

**Functional Requirements**
- FR-FSM-003 — AEB activation enablement (normalisation direction corrected)

**Non-Functional Requirements**
- NFR-SAF-ROB — robustness under SEU / corrupted input (fail-safe direction now matches the V&V contract)
- NFR-COD-001 — MISRA C:2012 conformance reporting (Rule 10.5 cascade eliminated while preserving Rule 10.3 compliance)

## Artifacts Updated

- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [ ] Tests
- [ ] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

## Validation Evidence

- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes
- [x] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence

Local run on Ubuntu 24.04, gcc-14 14.3.0, cppcheck 2.13.0:

```
$ make test
...
test_decision: 9/9 PASS

$ make fault-decision
Results: 32 run, 32 passed, 0 failed
(all fault assertions PASS)

$ make misra-decision
MISRA findings in Decision scope: 8
  misra-c2012-15.5: 6   (Advisory, in gate's ADVISORY filter)
  misra-c2012-8.7:  2   (Advisory, in gate's ADVISORY filter)
  → 0 Rule 10.3 findings, 0 Rule 10.5 findings

$ make memory-decision
Valgrind test_decision:        (clean)
Valgrind test_decision_mcdc:   (clean)
Valgrind test_decision_fault:  (clean)
ASan+UBSan test_decision:      (clean)
ASan+UBSan test_decision_mcdc: (clean)
ASan+UBSan test_decision_fault:(clean)
```

Delta vs PR #107 post-merge state:
- `fault-decision`: 31/32 → **32/32** (C3 now passes as the V&V contract requires)
- `misra-decision`: 10 findings → **8 findings**, all Advisory already filtered by the gate's `ADVISORY` set; 0 Required/Mandatory remain

## Reviewer Notes

Focus points for review:

- **Semantic direction of `aeb_enabled_norm`** — `== 1U` is the strict-match, fail-safe-to-disabled interpretation. Confirm this matches the V&V Consolidated Report §7.2 expectation (and the `fault_c3_aeb_enabled_0xAA` assertion).
- **Ternary vs cast pattern** — consistency with PR #94 (UDS), PR #100 (PID), PR #102 (CAN encode). Same shape across all four module fixes.
- **Independence preserved** — no changes under `tests/` or `.github/workflows/`. The cross-validator re-runs the V&V stack post-merge per ISO 26262-6 §5.4.8.

## Risks / Open Points

- No API change, no behaviour change for the nominal path (legitimate `aeb_enabled == 1U` inputs continue to enable the FSM as before). All 9 nominal tests pass unchanged.
- Once this merges, the `vv-decision.yml` gate flip PR (mirroring PR #103 for UDS) becomes unblocked — both the fault-injection step and the MISRA Required step can drop `continue-on-error: true` and become blocking.
- Issue #92 (the original 5 Required MISRA findings from PR #107 scope) remains closed; this PR doesn't reopen it. The 2 Rule 10.5 findings that cascaded from the #92 remediation are what #109 tracks, and are now resolved.
