### PR TITLE
ci(vv-decision): promote fault-decision and MISRA Required gates to blocking

### DIFF
--- a/.github/workflows/vv-decision.yml
+++ b/.github/workflows/vv-decision.yml
@@ -1,10 +1,12 @@
 name: Decision V&V
 
 # Runs the ASIL-D V&V stack scoped to the Decision module (TTC + FSM).
-# On PRs to development/main the blocking gates (MC/DC, memory safety,
-# MISRA) must pass; fault-decision is non-blocking until the robustness
-# bugs are patched on fix/decision-robustness — flip `continue-on-error`
-# to `false` after that PR lands.
+# On PRs to development/main, four blocking gates must pass: MC/DC
+# coverage, dynamic memory safety, MISRA C:2012 conformance, and fault
+# injection. The fault-injection and MISRA Required gates became
+# blocking after PR #107 (fix/decision-robustness) and PR #111
+# (fix/decision-review-followup) closed all V&V findings; any new
+# regression is now treated as a CI failure, mirroring vv-uds.
 #
 # Reports are published as workflow artefacts on every run and to
 # GitHub Pages on push to development/main under
@@ -139,15 +141,14 @@ jobs:
             fi
           done
 
-      # ─── Non-blocking until fix/decision-misra lands ──────────────────────
-      # The 5 MISRA Required findings in aeb_ttc.c / aeb_fsm.c are tracked in
-      # a follow-up issue and will be patched on fix/decision-misra. After
-      # that PR merges, flip continue-on-error to false (or remove) so this
-      # gate becomes blocking again. The 7 Advisory findings (Rules 15.5,
-      # 8.7) are documented as deviations per ISO 26262-8 §9.4.2 in the
-      # consolidated V&V report §6.
-      - name: MISRA required/mandatory (0 findings in aeb_ttc/aeb_fsm)
-        continue-on-error: true
+      # ─── Blocking gate 3: MISRA C:2012 Required (0 findings in scope) ────
+      # Promoted to blocking after PR #107 (fix/decision-robustness) closed
+      # the 5 Required findings from issue #92 and PR #111 eliminated the
+      # Rule 10.5 cascade. The Advisory findings (Rules 15.5, 8.7) remain
+      # documented as deviations per ISO 26262-8 §9.4.2 in the consolidated
+      # V&V report §6 and are filtered out below via the `accepted_deviations`
+      # set.
+      - name: MISRA Required/Mandatory (0 findings in aeb_ttc/aeb_fsm)
         run: |
           make misra-decision
           DEC_ISSUES=$(python3 - <<'PY'
@@ -184,9 +185,13 @@ jobs:
             exit 1
           fi
 
-      # ─── Non-blocking (reports-only) until fix/decision-robustness lands ──
-      - name: Fault injection (non-blocking until bugs patched)
-        continue-on-error: true
+      # ─── Blocking gate 4: fault injection (32/32 required) ────────────────
+      # Promoted to blocking after PR #107 (fix/decision-robustness) patched
+      # the four robustness bugs and PR #111 corrected the aeb_enabled SEU
+      # semantic. Any new fault-injection regression is now treated as a CI
+      # failure — this gate guards against the exact classes of defects that
+      # V&V cross-validation originally surfaced.
+      - name: Fault injection
         run: make fault-decision
 
       - name: Generate HTML reports

--- a/Makefile
+++ b/Makefile
@@ -316,16 +316,9 @@ fault-decision:
 	@mkdir -p $(VV_REPORT_DIR)/fault_injection
 	$(CC) $(CFLAGS) -O0 -g -o $(VV_REPORT_DIR)/fault_injection/test_decision_fault \
 		$(SRC_DECISION_FAULT_TEST) $(LDFLAGS)
-	@$(VV_REPORT_DIR)/fault_injection/test_decision_fault \
-		> $(VV_REPORT_DIR)/fault_injection/run.log 2>&1; \
+	@$(VV_REPORT_DIR)/fault_injection/test_decision_fault > $(VV_REPORT_DIR)/fault_injection/run.log 2>&1; \
 		rc=$$?; \
 		cat $(VV_REPORT_DIR)/fault_injection/run.log; \
-		echo ""; \
-		if [ "$$rc" = "0" ]; then \
-			echo "(all fault assertions PASS — flip continue-on-error to false in vv-decision.yml)"; \
-		else \
-			echo "(non-zero exit expected while bugs are pending patch)"; \
-		fi; \
 		exit $$rc
 
 memory-decision:


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from the **fault-injection** step in `.github/workflows/vv-decision.yml` — now blocking. All 32 fault assertions passing locally after PR #107 + PR #111 closed the four robustness bugs and corrected the `aeb_enabled` SEU direction.
- Remove `continue-on-error: true` from the **MISRA Required/Mandatory** step — now blocking. Gate counts 0 Required/Mandatory findings after PR #107 closed the 5 from issue #92 and PR #111 eliminated the Rule 10.5 cascade; the 8 remaining Advisory findings (Rule 15.5 ×6, Rule 8.7 ×2) are already filtered by the existing `accepted_deviations` set.
- Rewrite the top-of-file comment to reflect the four-gate blocking policy (MC/DC + memory safety + MISRA + fault, all required to pass).
- Rename the two steps to drop the `(non-blocking until bugs patched)` / `(0 findings in aeb_ttc/aeb_fsm)` qualifiers — the steps do what their name says, no TODO language.
- Simplify `fault-decision` recipe in the Makefile: drop the `if/else` echo that pointed maintainers at the flip-to-blocking TODO (now done). Preserves `rc=$?; cat ...; exit $rc` so the CI step colour reflects the real exit code.

## Related Issue

- Closes #88 for the Decision scope (fault-`<module>` echo-anti-pattern follow-through under the post-fix-landed phase; UDS half was closed by PR #103)

## Change Type

- [x] ci
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] test
- [ ] refactor/chore

## AEB Areas Affected

- [x] Decision Logic

## Requirements Impacted

**Non-Functional Requirements**
- NFR-COD-001 — MISRA C:2012 conformance reporting (gate now enforcing 0 Required/Mandatory in scope)
- NFR-SAF-002 — fault tolerance evidence via fault injection (gate now enforcing 32/32)

## Artifacts Updated

- [x] CI workflow
- [x] Build system (Makefile)

## Validation Evidence

- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes (will be verified by this PR's own run on `development`)
- [x] Traceability updated (YAML docstring + commit body cite PR #107 and PR #111 lineage)
- [x] Safety-relevant impact assessed

## Evidence

Local run on Ubuntu 24.04, gcc-14 14.3.0, cppcheck 2.13.0, valgrind 3.22.0:

```
$ make test
test_decision: 9/9 PASS

$ make fault-decision
Results: 32 run, 32 passed, 0 failed

$ make misra-decision
MISRA Required/Mandatory findings in Decision scope: 0 -> PASS
(8 total findings, all Advisory filtered by ADVISORY set:
  misra-c2012-15.5: 6
  misra-c2012-8.7:  2)

$ make memory-decision
(all 6 logs clean: Valgrind x3 + ASan/UBSan x3)
```

## Reviewer Notes

Focus points for review:

- **Symmetry with PR #103.** Same shape applied to `vv-uds.yml` when `fix/uds-robustness` landed. Decision now joins UDS in the four-gate blocking set.
- **Comment narrative.** Top-of-file docstring now says "four blocking gates" and cites PR #107 and #111 as the gating events. Future maintainer reading either workflow sees a coherent story.
- **Makefile recipe simplification.** The conditional `if [ "$$rc" = "0" ]; then ...` block is removed; the recipe now always prints the log and exits with the real rc. No behaviour change — only dead messaging gone.
- **Scope discipline.** Two files (`vv-decision.yml`, `Makefile`), one commit, 22 insertions / 24 deletions. No test, no module source, no other workflow touched.

## Risks / Open Points

- First CI run on this branch will exercise the newly-blocking gates against the post-#111 state. Expected: green across all four gates plus the existing MC/DC coverage step.
- If any future PR in Decision scope regresses fault-injection or re-introduces a MISRA Required finding, it will now fail the gate and block merge. That's the intent.
- Optional follow-up: evidence refresh under `reports/vv_decision/` (text/XML/log files currently reflect state regenerated during the validation runs) — not in scope here to keep the PR tight. Would belong in a separate `docs(vv-decision): refresh V&V evidence post-fix` PR before delivery cut.
