### PR TITLE
fix(perception): use explicit != 0 on isfinite guard for MISRA 14.4

### DIFF
--- a/src/perception/aeb_perception.c
+++ b/src/perception/aeb_perception.c
@@ -292,7 +292,7 @@ void perception_step(const raw_sensor_input_t *in, perception_output_t *out)
 
     out->fault_flag = 0U;
 
-    if (isfinite(in->v_ego)) {
+    if (isfinite(in->v_ego) != 0) {
         out->v_ego = in->v_ego;
     } else {
         out->v_ego       = 0.0f;


### PR DESCRIPTION
## Summary

- Replace `if (isfinite(in->v_ego))` with `if (isfinite(in->v_ego) != 0)` in `perception_step` to satisfy MISRA C:2012 Rule 14.4 (Required). The previous form made a `int`-returning macro the direct controlling expression of an `if` — not essentially Boolean per Rule 14.4's definition.
- Zero behavioural change (same conditional outcome, same generated code), zero performance delta, zero effect on any test.
- One line in `src/perception/aeb_perception.c`. No test file touched, no CI workflow touched, no other module touched.

## Related Issue

- Closes #114 

## Change Type

- [x] fix
- [ ] feat
- [ ] ci
- [ ] docs
- [ ] test
- [ ] refactor/chore

## AEB Areas Affected

- [x] Perception

## Requirements Impacted

**Non-Functional Requirements**
- NFR-COD-001 — MISRA C:2012 conformance reporting (Rule 14.4 Required, now satisfied without deviation)

## Artifacts Updated

- [x] C source code

## Validation Evidence

- [x] Local build passes
- [x] Automated tests pass
- [ ] CI passes (verified by this PR's own CI run)
- [x] Traceability updated
- [x] Safety-relevant impact assessed

## Evidence

Local run on Ubuntu 24.04, gcc-14 14.3.0, cppcheck 2.13.0:

```
$ make test
test_perception: 25/25 PASS

$ cppcheck --addon=misra ... src/perception/aeb_perception.c include/aeb_perception.h
Rule 14.4 findings in Perception scope: 0  (was 1 at aeb_perception.c:295)
Remaining findings: 3 × Rule 15.5 (Advisory, pre-existing deviations, unchanged)
```

## Reviewer Notes

- The `isfinite()` macro is documented by ISO C99 §7.12.3.2 as returning `int` (0 or non-zero). Wrapping in `!= 0` produces an essentially Boolean controlling expression, which is what Rule 14.4 requires.
- No other `isfinite()` site in `aeb_perception.c` flags Rule 14.4 — the others are inside ternary assignments (lines 42, 89, 151, 153) or compound `&&` chains (line 157), which cppcheck accepts.
- Once merged, the `accepted_deviations` set in `vv-perception.yml` (PR #104) can drop `misra-c2012-14.4` — follow-up commit on that branch.

## Risks / Open Points

- No regression risk — the condition `isfinite(x) != 0` is equivalent to `isfinite(x)` under C semantics (zero is false, non-zero is true). Compiler generates the same code at `-O2`.
- Coordination with PR #104: @jessica-leoa can remove the Rule 14.4 deviation filter once this PR merges. Her PR doesn't depend on this landing first, but benefits from it for a cleaner filter set.
