### PR TITLE
feat(sil): UDS Diagnostic scenario — client, REST endpoints, dashboard panel

### DIFF
--- a/sil/aeb_gazebo/README.md
+++ b/sil/aeb_gazebo/README.md
@@ -49,15 +49,85 @@ graph LR
 
 | Scenario | Ego speed | Target speed | Initial gap | Description |
 |----------|-----------|--------------|-------------|-------------|
-| `ccrs_20`     | 20 km/h | 0 km/h  | 100 m | Car-to-Car Rear Stationary |
-| `ccrs_30`     | 30 km/h | 0 km/h  | 100 m | |
-| `ccrs_40`     | 40 km/h | 0 km/h  | 100 m | |
-| `ccrs_50`     | 50 km/h | 0 km/h  | 100 m | |
-| `ccrm`        | 50 km/h | 20 km/h |  50 m | Car-to-Car Rear Moving |
-| `ccrb_d2_g12` | 50 km/h | 50 km/h |  12 m | Car-to-Car Rear Braking (decel = 2 m/s²) |
-| `ccrb_d6_g12` | 50 km/h | 50 km/h |  12 m | Car-to-Car Rear Braking (decel = 6 m/s²) |
-| `ccrb_d2_g40` | 50 km/h | 50 km/h |  40 m | Car-to-Car Rear Braking (decel = 2 m/s²) |
-| `ccrb_d6_g40` | 50 km/h | 50 km/h |  40 m | Car-to-Car Rear Braking (decel = 6 m/s²) |
+| `ccrs_20`        | 20 km/h | 0 km/h  | 100 m | Car-to-Car Rear Stationary |
+| `ccrs_30`        | 30 km/h | 0 km/h  | 100 m | |
+| `ccrs_40`        | 40 km/h | 0 km/h  | 100 m | |
+| `ccrs_50`        | 50 km/h | 0 km/h  | 100 m | |
+| `ccrm`           | 50 km/h | 20 km/h |  50 m | Car-to-Car Rear Moving |
+| `ccrb_d2_g12`    | 50 km/h | 50 km/h |  12 m | Car-to-Car Rear Braking (decel = 2 m/s²) |
+| `ccrb_d6_g12`    | 50 km/h | 50 km/h |  12 m | Car-to-Car Rear Braking (decel = 6 m/s²) |
+| `ccrb_d2_g40`    | 50 km/h | 50 km/h |  40 m | Car-to-Car Rear Braking (decel = 2 m/s²) |
+| `ccrb_d6_g40`    | 50 km/h | 50 km/h |  40 m | Car-to-Car Rear Braking (decel = 6 m/s²) |
+| `uds_diagnostic` |  0 km/h | 0 km/h  | 100 m | Stationary harness for the UDS diagnostic panel — no motion, no AEB activity. |
+
+---
+
+## UDS Diagnostics (runtime)
+
+The Zephyr ECU answers UDS services (ISO 14229) over CAN — IDs
+`0x7DF` (request) and `0x7E8` (response) — completing FR-UDS-005
+end-to-end. The SIL exposes those services via HTTP on the `api`
+container and via a side panel in the `dashboard`.
+
+### REST endpoints (`api`, port `:8000`)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/uds/health`          | GET  | Connection state with `canbus` |
+| `/uds/read_did/{did}`  | GET  | `ReadDataByIdentifier` (0x22). Accepts `0xF101` or `61697` |
+| `/uds/snapshot`        | GET  | Reads `0xF100` + `0xF101` + `0xF102` in one call |
+| `/uds/clear_dtc`       | POST | `ClearDiagnosticInformation` (0x14) — clears all DTCs |
+| `/uds/routine_control` | POST | `RoutineControl` (0x31). Body: `{"rid": 769, "value": 0\|1}` |
+
+DIDs supported by the ECU (see `include/aeb_uds.h`):
+
+| DID      | Content              | Decoding |
+|----------|----------------------|----------|
+| `0xF100` | TTC (seconds)        | uint16 little-endian, scale 1/100 |
+| `0xF101` | FSM state            | uint8 raw (0 OFF .. 6 POST_BRAKE) |
+| `0xF102` | Brake pressure (%)   | uint16 little-endian, scale 1/10 |
+
+Known RID: `0x0301` (AEB enable/disable; value `0` disables, `1` enables).
+
+### Dashboard panel
+
+The **UDS** button on the scenario bar (top of the Gazebo iframe)
+opens a side panel that polls `/uds/snapshot` at 5 Hz, displays all
+three DIDs live, and exposes two controls:
+
+- **Clear DTCs (0x14)** — emits `ClearDiagnosticInformation`.
+- **AEB enabled / DISABLED** — toggle via `RoutineControl` on RID `0x0301`.
+
+The panel keeps a colour-coded log of the last 30 actions (green for
+success, red for UDS or HTTP errors).
+
+### Recommended demo flow
+
+```bash
+# After docker compose up, in the dashboard:
+#   1. Pick the 'uds_diagnostic' scenario and click Start.
+#   2. Click the UDS button to open the side panel.
+#   3. Observe FSM = STANDBY and brake = 0%.
+#   4. Click "AEB: enabled" to disable; watch the log row and the
+#      next reads reflect the change.
+```
+
+### Reusable Python client
+
+For external testing or scripting, import the client directly:
+
+```python
+from uds_client import UDSClient, DID_FSM_STATE, RID_AEB_CONTROL
+
+client = UDSClient(host="localhost", port=29536)  # if mapped in compose
+print(client.read_did(DID_FSM_STATE))
+client.routine_control(RID_AEB_CONTROL, value=0)
+```
+
+Unit tests live at
+[`sil/docker/api/tests/test_uds_client.py`](../docker/api/tests/test_uds_client.py)
+and cover encoding/decoding, negative responses, timeouts, and
+concurrent serialisation. Run with `pytest` from `sil/docker/api/`.
 
 ---
 

--- a/sil/aeb_gazebo/config/scenarios.yaml
+++ b/sil/aeb_gazebo/config/scenarios.yaml
@@ -39,6 +39,19 @@ scenarios:
     target_brake_time: 0.0
     pass_criterion: "v_impact < 5 km/h"
 
+  # AEB disabled — control run, demonstrates what happens without intervention.
+  # Identical to ccrs_50 but the api fires UDS RoutineControl(0x0301, 0)
+  # right after the ECU restart, so the FSM stays in OFF the entire run.
+  ccrs_50_no_aeb:
+    name: "CCRs - Ego 50 km/h (AEB DISABLED)"
+    ego_speed_kmh: 50.0
+    target_speed_kmh: 0.0
+    initial_gap_m: 100.0
+    target_decel: 0.0
+    target_brake_time: 0.0
+    pass_criterion: "control run — AEB intentionally off"
+    disable_aeb: true
+
   # CCRm: Car-to-Car Rear Moving
   # Initial gap 50 m: closing speed is 30 km/h (8.3 m/s), so 50 m = ~6 s
   # approach. With 100 m the run was unnecessarily long for visualization.

--- a/sil/aeb_gazebo/config/scenarios.yaml
+++ b/sil/aeb_gazebo/config/scenarios.yaml
@@ -87,3 +87,16 @@ scenarios:
     target_decel: -6.0
     target_brake_time: 2.0
     pass_criterion: "v_impact < 15 km/h"
+
+  # Diagnostic mode: ego stopped, target far enough that the FSM stays
+  # in STANDBY. The dashboard's UDS panel drives ReadDID / ClearDTC /
+  # RoutineControl over the canbus relay; this scenario gives it a
+  # quiescent baseline so the responses reflect "system idle" semantics.
+  uds_diagnostic:
+    name: "UDS Diagnostic - quiescent baseline"
+    ego_speed_kmh: 0.0
+    target_speed_kmh: 0.0
+    initial_gap_m: 100.0
+    target_decel: 0.0
+    target_brake_time: 0.0
+    pass_criterion: "n/a (diagnostic mode)"

--- a/sil/aeb_gazebo/src/perception_node.py
+++ b/sil/aeb_gazebo/src/perception_node.py
@@ -29,6 +29,7 @@ Parameters:
 import rclpy
 from rclpy.node import Node
 from nav_msgs.msg import Odometry
+from std_msgs.msg import Int32
 import math
 import time
 import random
@@ -99,9 +100,21 @@ class PerceptionNode(Node):
         self.last_fusion_time = None
         self.fault_counter = 0
 
+        # Driver AEB-enable bit broadcast in CAN 0x101. Default 1 (AEB on);
+        # the API publishes 0 to /aeb/driver_aeb_enable when starting a
+        # `disable_aeb: true` scenario. The production C ECU's FSM
+        # Priority-1 reads `state->driver.aeb_enabled`, which is overwritten
+        # from this CAN frame every cycle — so toggling this bit at the
+        # source is the only way to keep AEB off across cycles. (UDS
+        # RoutineControl 0x0301 writes to state->uds.aeb_enabled, a
+        # separate field not consumed by the FSM.)
+        self.driver_aeb_enable = 1
+
         # ── ROS 2 subscriptions (from Gazebo) ─────────────────────────────
         self.create_subscription(Odometry, '/aeb/ego/odom', self.ego_odom_cb, 10)
         self.create_subscription(Odometry, '/aeb/target/odom', self.target_odom_cb, 10)
+        self.create_subscription(Int32, '/aeb/driver_aeb_enable',
+                                 self.aeb_enable_cb, 10)
 
         # ── Timers ────────────────────────────────────────────────────────
         self.create_timer(0.01, self.publish_ego_vehicle)     # 10 ms
@@ -237,13 +250,20 @@ class PerceptionNode(Node):
         )
         self._can_send(CAN_ID_EGO_VEHICLE, data)
 
+    def aeb_enable_cb(self, msg):
+        """Latched override for the AEB-enable bit broadcast in CAN 0x101.
+        Set by the API when the scenario YAML has `disable_aeb: true`."""
+        self.driver_aeb_enable = 1 if msg.data else 0
+        self.get_logger().info(
+            f'driver_aeb_enable set to {self.driver_aeb_enable}')
+
     def publish_driver_input(self):
         if not self.odom_ready:
             return
         data = encode_driver_input(
             brake_pct=0,
             accel_pct=0,
-            aeb_enable=1,
+            aeb_enable=self.driver_aeb_enable,
             override=0,
         )
         self._can_send(CAN_ID_DRIVER_INPUT, data)

--- a/sil/aeb_gazebo/src/scenario_controller.py
+++ b/sil/aeb_gazebo/src/scenario_controller.py
@@ -279,6 +279,31 @@ class ScenarioController(Node):
                     return
             self.publish_vel(self.ego_cmd_pub, 0.0)
             self.publish_vel(self.target_cmd_pub, 0.0)
+            # Keep refreshing /tmp/aeb_live.json so the dashboard reflects the
+            # current ECU state (FSM transitions to POST_BRAKE → STANDBY,
+            # brake release, etc.) even after the scenario's end-condition has
+            # fired. Without this, the dashboard freezes on the last values
+            # written before STOPPED — which is misleading for scenarios like
+            # `uds_diagnostic` that end early by design.
+            try:
+                import json
+                with self.can_lock:
+                    fsm = self.fsm_state_name
+                    brake_pct = self.brake_cmd_pct
+                distance = max(0.0, self.target_x - self.ego_x - 4.5)
+                ego_speed_kmh = self.ego_vx * 3.6
+                live = {
+                    'time': 0.0,
+                    'distance': round(distance, 1),
+                    'speed_kmh': round(ego_speed_kmh, 1),
+                    'brake_pct': round(brake_pct, 0),
+                    'fsm_state': fsm,
+                    'ttc': 10.0,
+                }
+                with open('/tmp/aeb_live.json', 'w') as f:
+                    json.dump(live, f)
+            except Exception:
+                pass
             return
 
         if not self.scenario_running:

--- a/sil/docker/api/scenario_api.py
+++ b/sil/docker/api/scenario_api.py
@@ -2,19 +2,27 @@
 Scenario Control REST API
 =========================
 FastAPI server that bridges HTTP requests to ROS 2 services/topics
-for controlling AEB simulation scenarios.
+for controlling AEB simulation scenarios, plus UDS diagnostics over
+the SIL's TCP CAN relay.
 
 Runs inside a container with ROS 2 sourced.
 
 Endpoints:
-  GET  /scenarios          — list available scenarios
-  POST /scenarios/start    — start/restart a scenario by name
-  POST /scenarios/stop     — pause the simulation
-  POST /scenarios/restart  — restart the current scenario
-  GET  /status             — current scenario status
+  GET  /scenarios            — list available scenarios
+  POST /scenarios/start      — start/restart a scenario by name
+  POST /scenarios/stop       — pause the simulation
+  POST /scenarios/restart    — restart the current scenario
+  GET  /status               — current scenario status
+  GET  /live                 — live telemetry snapshot
+
+  GET  /uds/health           — UDS connection status
+  GET  /uds/read_did/{did}   — ReadDataByIdentifier (0x22)
+  GET  /uds/snapshot         — read all three DIDs in one call
+  POST /uds/clear_dtc        — ClearDiagnosticInformation (0x14)
+  POST /uds/routine_control  — RoutineControl (0x31), e.g. AEB enable
 """
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import yaml
@@ -29,6 +37,11 @@ try:
 except Exception as _e:  # noqa: BLE001 — log but degrade gracefully
     print(f"[api] docker SDK unavailable ({_e!r}) — ECU restart disabled", flush=True)
     _docker_client = None
+
+from api.uds_client import (
+    UDSClient, UDSError, UDSTimeout,
+    DID_TTC, DID_FSM_STATE, DID_BRAKE_PRESS, RID_AEB_CONTROL,
+)
 
 app = FastAPI(title="AEB Scenario Control", version="1.0")
 
@@ -258,3 +271,158 @@ def get_live_data():
             "time": 0, "distance": 0, "speed_kmh": 0,
             "brake_pct": 0, "fsm_state": "OFF", "ttc": 10.0
         }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  UDS Diagnostics  (FR-UDS-001..005)
+# ═══════════════════════════════════════════════════════════════════════════
+
+CANBUS_HOST = os.environ.get("CAN_TCP_HOST", "canbus")
+CANBUS_PORT = int(os.environ.get("CAN_TCP_PORT", "29536"))
+
+_uds_client = None
+_uds_lock   = threading.Lock()
+
+
+def _get_uds_client():
+    """Lazy-construct the UDS client on first use so the api container
+    starts even when canbus is still coming up. Reconnects after a
+    drop on the next call."""
+    global _uds_client
+    with _uds_lock:
+        if _uds_client is None:
+            try:
+                _uds_client = UDSClient(
+                    host=CANBUS_HOST, port=CANBUS_PORT, response_timeout=0.5
+                )
+            except ConnectionError as e:
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"UDS client cannot reach canbus: {e}",
+                )
+        return _uds_client
+
+
+def _reset_uds_client():
+    """Drop the client so the next call rebuilds it (after a transport error)."""
+    global _uds_client
+    with _uds_lock:
+        if _uds_client is not None:
+            try:
+                _uds_client.close()
+            except Exception:
+                pass
+            _uds_client = None
+
+
+def _parse_did(did_str: str) -> int:
+    """Accept '0xF101', 'F101', or '61697'."""
+    s = did_str.strip()
+    try:
+        return int(s, 16) if s.lower().startswith("0x") or any(
+            c in s.lower() for c in "abcdef"
+        ) else int(s)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid DID: {did_str!r} (expected 0xF101 or 61697)"
+        )
+
+
+class RoutineControlRequest(BaseModel):
+    rid: int
+    value: int
+
+
+@app.get("/uds/health")
+def uds_health():
+    """Report whether the UDS client is connected to canbus."""
+    return {
+        "host":      CANBUS_HOST,
+        "port":      CANBUS_PORT,
+        "connected": _uds_client is not None,
+    }
+
+
+@app.get("/uds/read_did/{did}")
+def uds_read_did(did: str):
+    """ReadDataByIdentifier (0x22). DIDs supported by the ECU:
+        0xF100  TTC value (s)
+        0xF101  FSM state
+        0xF102  Brake pressure (%)
+    """
+    did_val = _parse_did(did)
+    client = _get_uds_client()
+    try:
+        return client.read_did(did_val)
+    except UDSTimeout as e:
+        _reset_uds_client()
+        raise HTTPException(status_code=504, detail=str(e))
+    except UDSError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": str(e),
+                "sid":     e.sid,
+                "nrc":     e.nrc,
+            },
+        )
+
+
+@app.get("/uds/snapshot")
+def uds_snapshot():
+    """Convenience endpoint — read all three live DIDs in one call.
+    Used by the dashboard's UDS panel for periodic polling."""
+    client = _get_uds_client()
+    out = {}
+    for label, did in (("ttc", DID_TTC),
+                       ("fsm", DID_FSM_STATE),
+                       ("brake", DID_BRAKE_PRESS)):
+        try:
+            out[label] = client.read_did(did)
+        except UDSTimeout as e:
+            _reset_uds_client()
+            out[label] = {"error": "timeout", "detail": str(e)}
+        except UDSError as e:
+            out[label] = {
+                "error": "uds_error",
+                "detail": str(e),
+                "sid":    e.sid,
+                "nrc":    e.nrc,
+            }
+    return out
+
+
+@app.post("/uds/clear_dtc")
+def uds_clear_dtc():
+    """ClearDiagnosticInformation (0x14) — clears all DTCs."""
+    client = _get_uds_client()
+    try:
+        return client.clear_dtc()
+    except UDSTimeout as e:
+        _reset_uds_client()
+        raise HTTPException(status_code=504, detail=str(e))
+    except UDSError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={"message": str(e), "sid": e.sid, "nrc": e.nrc},
+        )
+
+
+@app.post("/uds/routine_control")
+def uds_routine_control(req: RoutineControlRequest):
+    """RoutineControl (0x31). For AEB enable/disable use RID 0x0301
+    with value 0 (disable) or 1 (enable)."""
+    client = _get_uds_client()
+    try:
+        return client.routine_control(req.rid, req.value)
+    except UDSTimeout as e:
+        _reset_uds_client()
+        raise HTTPException(status_code=504, detail=str(e))
+    except UDSError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={"message": str(e), "sid": e.sid, "nrc": e.nrc},
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/sil/docker/api/scenario_api.py
+++ b/sil/docker/api/scenario_api.py
@@ -203,6 +203,27 @@ def start_scenario(req: StartRequest):
     time.sleep(0.5)
     restart_aeb_ecu()
 
+    # AEB enable bit handling for the scenario:
+    #   1) Toggle perception_node's CAN 0x101 broadcast (via ROS topic)
+    #      so the production C `state->driver.aeb_enabled` field — which
+    #      `aeb_core.c` overwrites from CAN every cycle — actually carries
+    #      the right value for the run.
+    #   2) Also fire the UDS RoutineControl as a defensive belt-and-suspenders
+    #      (writes to state->uds.aeb_enabled; cosmetic since the FSM reads
+    #      the driver field, but keeps the UDS panel display consistent).
+    aeb_enable_value = 0 if cfg.get("disable_aeb") else 1
+    ros2_pub("/aeb/driver_aeb_enable", "std_msgs/msg/Int32",
+             f'{{data: {aeb_enable_value}}}')
+    if cfg.get("disable_aeb"):
+        try:
+            client = _get_uds_client()
+            client.routine_control(RID_AEB_CONTROL, value=0)
+            print(f"[api] disable_aeb=true for {req.scenario} — AEB disabled via "
+                  f"perception 0x101 + UDS RoutineControl", flush=True)
+        except (UDSError, UDSTimeout, ConnectionError, OSError) as e:
+            print(f"[api] could not disable AEB via UDS: {e!r}", flush=True)
+            _reset_uds_client()
+
     with lock:
         current_scenario["status"] = "running"
 

--- a/sil/docker/api/tests/test_uds_client.py
+++ b/sil/docker/api/tests/test_uds_client.py
@@ -1,0 +1,307 @@
+"""
+Unit tests for sil/docker/api/uds_client.py
+
+Drives the client against a local fake TCP relay that mimics
+sil/docker/canbus/can_tcp_server.py (16-byte frames) without needing
+the full SIL stack.
+
+Run from the repo root:
+    cd sil/docker/api
+    python -m pytest tests/test_uds_client.py -v
+"""
+
+import socket
+import struct
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from uds_client import (    # noqa: E402  (import after sys.path tweak)
+    UDSClient, UDSError, UDSTimeout,
+    CAN_ID_REQUEST, CAN_ID_RESPONSE,
+    SID_READ_DID, SID_READ_DID_RESP,
+    SID_CLEAR_DTC, SID_CLEAR_DTC_RESP,
+    SID_ROUTINE_CTRL, SID_ROUTINE_RESP,
+    SID_NEGATIVE, NRC_REQUEST_OOR,
+    DID_TTC, DID_FSM_STATE, DID_BRAKE_PRESS,
+    RID_AEB_CONTROL,
+    FRAME_SIZE,
+)
+
+
+# ── Fake TCP CAN relay ────────────────────────────────────────────────────
+
+def _pack_frame(arb_id: int, payload: bytes) -> bytes:
+    return struct.pack("<IBxxx", arb_id, len(payload)) \
+         + payload.ljust(8, b"\x00")
+
+
+def _unpack_frame(frame: bytes):
+    arb_id = struct.unpack("<I", frame[0:4])[0]
+    dlc    = frame[4]
+    payload = frame[8:8 + min(dlc, 8)]
+    return arb_id, dlc, payload
+
+
+class FakeRelay:
+    """Single-client TCP server that captures sent frames and replies on demand."""
+
+    def __init__(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(1)
+        self.port = self.sock.getsockname()[1]
+        self.conn = None
+        self.received = []   # list of (arb_id, dlc, payload)
+        self._reply_payload = None
+        self._reply_after = 0.0
+        self._auto_reply_fn = None
+        self._stop = threading.Event()
+        self._t = threading.Thread(target=self._run, daemon=True)
+        self._t.start()
+
+    def set_reply(self, payload: bytes, *, after_seconds: float = 0.0):
+        """Queue a single reply to the next request seen."""
+        self._reply_payload = payload
+        self._reply_after = after_seconds
+
+    def set_auto_reply(self, fn):
+        """Use a function (request_payload -> response_payload) to reply to
+        every request automatically. Returning None drops the request."""
+        self._auto_reply_fn = fn
+
+    def expect_no_reply(self):
+        self._reply_payload = None
+        self._auto_reply_fn = None
+
+    def _run(self):
+        self.sock.settimeout(2.0)
+        try:
+            self.conn, _ = self.sock.accept()
+        except socket.timeout:
+            return
+        self.conn.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                data = b""
+                while len(data) < FRAME_SIZE:
+                    chunk = self.conn.recv(FRAME_SIZE - len(data))
+                    if not chunk:
+                        return
+                    data += chunk
+                arb_id, dlc, payload = _unpack_frame(data)
+                self.received.append((arb_id, dlc, payload))
+                if arb_id != CAN_ID_REQUEST:
+                    continue
+                reply = None
+                if self._auto_reply_fn is not None:
+                    reply = self._auto_reply_fn(payload)
+                elif self._reply_payload is not None:
+                    reply = self._reply_payload
+                    self._reply_payload = None
+                if reply is not None:
+                    if self._reply_after > 0:
+                        time.sleep(self._reply_after)
+                    self.conn.sendall(_pack_frame(CAN_ID_RESPONSE, reply))
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+
+    def close(self):
+        self._stop.set()
+        try:
+            if self.conn:
+                self.conn.close()
+        except OSError:
+            pass
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+@pytest.fixture()
+def relay_and_client():
+    """Spin up a FakeRelay and a UDSClient pointed at it."""
+    relay = FakeRelay()
+    client = UDSClient(host="127.0.0.1", port=relay.port, response_timeout=0.4)
+    yield relay, client
+    client.close()
+    relay.close()
+
+
+# ── Request encoding ──────────────────────────────────────────────────────
+
+def test_read_did_request_wire_format(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([SID_READ_DID_RESP, 0xF1, 0x01, 1, 0, 0, 0, 0]))
+    client.read_did(DID_FSM_STATE)
+    assert len(relay.received) == 1
+    arb_id, dlc, payload = relay.received[0]
+    assert arb_id == CAN_ID_REQUEST
+    assert dlc == 4
+    assert payload == bytes([SID_READ_DID, 0xF1, 0x01, 0x00])
+
+
+def test_clear_dtc_request_wire_format(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([SID_CLEAR_DTC_RESP, 0, 0, 0, 0, 0, 0, 0]))
+    client.clear_dtc()
+    arb_id, dlc, payload = relay.received[0]
+    assert arb_id == CAN_ID_REQUEST
+    assert dlc == 4
+    assert payload == bytes([SID_CLEAR_DTC, 0xFF, 0xFF, 0xFF])
+
+
+def test_routine_control_request_wire_format(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([SID_ROUTINE_RESP, 0x03, 0x01, 0, 0, 0, 0, 0]))
+    client.routine_control(RID_AEB_CONTROL, value=0)
+    arb_id, dlc, payload = relay.received[0]
+    assert arb_id == CAN_ID_REQUEST
+    assert dlc == 4
+    assert payload == bytes([SID_ROUTINE_CTRL, 0x03, 0x01, 0x00])
+
+
+# ── Response decoding (positive cases) ────────────────────────────────────
+
+def test_read_did_fsm_state_decodes(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([SID_READ_DID_RESP, 0xF1, 0x01, 3, 0, 0, 0, 0]))
+    result = client.read_did(DID_FSM_STATE)
+    assert result["did"] == DID_FSM_STATE
+    assert result["fsm_state"] == 3
+    assert result["fsm_state_name"] == "BRAKE_L1"
+    assert result["raw"] == [3, 0, 0, 0, 0]
+
+
+def test_read_did_ttc_decodes(relay_and_client):
+    relay, client = relay_and_client
+    # raw uint16 = 350 (0x015E) → ttc_s = 3.50
+    relay.set_reply(bytes([
+        SID_READ_DID_RESP, 0xF1, 0x00, 0x5E, 0x01, 0, 0, 0
+    ]))
+    result = client.read_did(DID_TTC)
+    assert result["ttc_s"] == pytest.approx(3.50)
+
+
+def test_read_did_brake_press_decodes(relay_and_client):
+    relay, client = relay_and_client
+    # raw uint16 = 750 (0x02EE) → brake_pct = 75.0
+    relay.set_reply(bytes([
+        SID_READ_DID_RESP, 0xF1, 0x02, 0xEE, 0x02, 0, 0, 0
+    ]))
+    result = client.read_did(DID_BRAKE_PRESS)
+    assert result["brake_pct"] == pytest.approx(75.0)
+
+
+def test_clear_dtc_positive_response(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([SID_CLEAR_DTC_RESP, 0, 0, 0, 0, 0, 0, 0]))
+    result = client.clear_dtc()
+    assert result["ok"] is True
+
+
+def test_routine_control_positive_response(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([SID_ROUTINE_RESP, 0x03, 0x01, 1, 0, 0, 0, 0]))
+    result = client.routine_control(RID_AEB_CONTROL, value=1)
+    assert result["ok"] is True
+    assert result["rid"] == RID_AEB_CONTROL
+    assert result["value"] == 1
+
+
+# ── Error paths ───────────────────────────────────────────────────────────
+
+def test_negative_response_raises_uds_error(relay_and_client):
+    relay, client = relay_and_client
+    relay.set_reply(bytes([
+        SID_NEGATIVE, SID_READ_DID, NRC_REQUEST_OOR, 0, 0, 0, 0, 0
+    ]))
+    with pytest.raises(UDSError) as exc_info:
+        client.read_did(0xF1FF)
+    assert exc_info.value.sid == SID_READ_DID
+    assert exc_info.value.nrc == NRC_REQUEST_OOR
+
+
+def test_response_timeout_raises(relay_and_client):
+    relay, client = relay_and_client
+    relay.expect_no_reply()
+    with pytest.raises(UDSTimeout):
+        client.read_did(DID_FSM_STATE)
+
+
+def test_did_echo_mismatch_raises(relay_and_client):
+    relay, client = relay_and_client
+    # Client asks for 0xF101 but the response echoes 0xF100
+    relay.set_reply(bytes([SID_READ_DID_RESP, 0xF1, 0x00, 1, 0, 0, 0, 0]))
+    with pytest.raises(UDSError, match="echoed DID"):
+        client.read_did(DID_FSM_STATE)
+
+
+def test_unexpected_response_sid_raises(relay_and_client):
+    relay, client = relay_and_client
+    # Client asks for ReadDID but server sends a RoutineControl positive response
+    relay.set_reply(bytes([SID_ROUTINE_RESP, 0xF1, 0x01, 0, 0, 0, 0, 0]))
+    with pytest.raises(UDSError, match="unexpected response SID"):
+        client.read_did(DID_FSM_STATE)
+
+
+def test_did_out_of_range_raises_value_error(relay_and_client):
+    _, client = relay_and_client
+    with pytest.raises(ValueError):
+        client.read_did(0x10000)
+
+
+def test_routine_value_out_of_range_raises(relay_and_client):
+    _, client = relay_and_client
+    with pytest.raises(ValueError):
+        client.routine_control(RID_AEB_CONTROL, value=256)
+
+
+# ── Concurrency ───────────────────────────────────────────────────────────
+
+def test_concurrent_requests_serialise(relay_and_client):
+    """Two threads issuing read_did simultaneously must each get a
+    well-formed response (the request lock serialises them so neither
+    thread reads the other's response)."""
+    relay, client = relay_and_client
+
+    # Auto-reply: echo the request DID with a STANDBY (state=1) value.
+    # That way each request gets its own reply with the correct echo,
+    # regardless of arrival order.
+    def echo_reply(req_payload):
+        # req_payload[0] = SID_READ_DID, [1:3] = DID, [3] = value byte
+        return bytes([
+            SID_READ_DID_RESP, req_payload[1], req_payload[2],
+            1, 0, 0, 0, 0,
+        ])
+    relay.set_auto_reply(echo_reply)
+
+    results = []
+    errors  = []
+
+    def hammer():
+        try:
+            for _ in range(3):
+                results.append(client.read_did(DID_FSM_STATE))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=hammer) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=4.0)
+    assert not errors, f"unexpected errors: {errors}"
+    # 2 threads x 3 requests each = 6 successful round-trips.
+    # If the request lock weren't there, the second thread could read
+    # the first's response and raise a DID echo mismatch.
+    assert len(results) == 6
+    assert all(r["fsm_state_name"] == "STANDBY" for r in results)

--- a/sil/docker/api/uds_client.py
+++ b/sil/docker/api/uds_client.py
@@ -1,0 +1,290 @@
+"""
+UDS Client over TCP-CAN
+=======================
+Synchronous UDS (ISO 14229) client that talks to the AEB ECU via the
+SIL's TCP CAN relay (`canbus`).
+
+Wire format on the relay matches `sil/docker/canbus/can_tcp_server.py`:
+    16 bytes per frame  =  4B ID  |  1B DLC  |  3B pad  |  8B data
+
+CAN IDs (production code, see include/aeb_can.h):
+    0x7DF  UDS request   TX from this client
+    0x7E8  UDS response  RX
+
+Services exposed (subset of ISO 14229):
+    0x22  ReadDataByIdentifier
+    0x14  ClearDiagnosticInformation
+    0x31  RoutineControl
+
+DIDs / RIDs (production code, see include/aeb_uds.h):
+    0xF100  TTC value          (data1+data2: uint16 little-endian, x100)
+    0xF101  FSM state          (data1: raw uint8)
+    0xF102  Brake pressure     (data1+data2: uint16 little-endian, x10)
+    0x0301  AEB enable/disable (RoutineControl, value byte: 0=disable, 1=enable)
+"""
+
+import socket
+import struct
+import threading
+import time
+from queue import Queue, Empty
+
+
+# ── Wire constants ────────────────────────────────────────────────────────
+
+FRAME_SIZE       = 16
+CAN_ID_REQUEST   = 0x7DF
+CAN_ID_RESPONSE  = 0x7E8
+
+SID_READ_DID         = 0x22
+SID_READ_DID_RESP    = 0x62
+SID_CLEAR_DTC        = 0x14
+SID_CLEAR_DTC_RESP   = 0x54
+SID_ROUTINE_CTRL     = 0x31
+SID_ROUTINE_RESP     = 0x71
+SID_NEGATIVE         = 0x7F
+
+NRC_SERVICE_NOT_SUPP = 0x11
+NRC_REQUEST_OOR      = 0x31
+
+DID_TTC          = 0xF100
+DID_FSM_STATE    = 0xF101
+DID_BRAKE_PRESS  = 0xF102
+RID_AEB_CONTROL  = 0x0301
+
+FSM_STATE_NAMES = {
+    0: "OFF",
+    1: "STANDBY",
+    2: "WARNING",
+    3: "BRAKE_L1",
+    4: "BRAKE_L2",
+    5: "BRAKE_L3",
+    6: "POST_BRAKE",
+}
+
+
+# ── Exceptions ────────────────────────────────────────────────────────────
+
+class UDSError(Exception):
+    """Raised on a negative response (NRC) or timeout."""
+
+    def __init__(self, message, *, sid=None, nrc=None):
+        super().__init__(message)
+        self.sid = sid
+        self.nrc = nrc
+
+
+class UDSTimeout(UDSError):
+    """Raised when the response does not arrive in time."""
+
+
+# ── Client ────────────────────────────────────────────────────────────────
+
+class UDSClient:
+    """Synchronous request/response UDS client.
+
+    A background thread reads frames from the TCP relay and pushes any
+    that match `CAN_ID_RESPONSE` onto a queue. Public methods are
+    thread-safe via a request lock so concurrent FastAPI handlers
+    serialize cleanly.
+    """
+
+    def __init__(self, host="canbus", port=29536, *, response_timeout=0.5):
+        self.host = host
+        self.port = port
+        self.response_timeout = response_timeout
+        self._sock = None
+        self._send_lock = threading.Lock()
+        self._req_lock  = threading.Lock()
+        self._rx_queue  = Queue()
+        self._rx_thread = None
+        self._stop_evt  = threading.Event()
+        self._connect()
+
+    # ── Connection management ─────────────────────────────────────────
+
+    def _connect(self, retries=30):
+        last_err = None
+        for _ in range(retries):
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect((self.host, self.port))
+                self._sock = s
+                self._stop_evt.clear()
+                self._rx_thread = threading.Thread(
+                    target=self._rx_loop, daemon=True
+                )
+                self._rx_thread.start()
+                return
+            except OSError as e:
+                last_err = e
+                time.sleep(1)
+        raise ConnectionError(
+            f"UDSClient: cannot connect to {self.host}:{self.port}: {last_err}"
+        )
+
+    def close(self):
+        self._stop_evt.set()
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self._sock.close()
+            self._sock = None
+
+    # ── Background RX thread ──────────────────────────────────────────
+
+    def _rx_loop(self):
+        while not self._stop_evt.is_set():
+            try:
+                data = b""
+                while len(data) < FRAME_SIZE:
+                    chunk = self._sock.recv(FRAME_SIZE - len(data))
+                    if not chunk:
+                        return
+                    data += chunk
+                arb_id = struct.unpack("<I", data[0:4])[0]
+                dlc    = data[4]
+                payload = data[8:8 + min(dlc, 8)]
+                if arb_id == CAN_ID_RESPONSE:
+                    self._rx_queue.put(payload)
+            except OSError:
+                return
+
+    # ── Frame I/O primitives ──────────────────────────────────────────
+
+    def _send_request(self, payload: bytes):
+        if len(payload) > 8:
+            raise ValueError("UDS request payload must fit in 8 bytes")
+        dlc = len(payload)
+        frame = struct.pack("<IBxxx", CAN_ID_REQUEST, dlc) \
+              + payload.ljust(8, b"\x00")
+        with self._send_lock:
+            self._sock.sendall(frame)
+
+    def _wait_response(self) -> bytes:
+        try:
+            return self._rx_queue.get(timeout=self.response_timeout)
+        except Empty:
+            raise UDSTimeout(
+                f"no UDS response within {self.response_timeout}s"
+            )
+
+    def _drain_queue(self):
+        while not self._rx_queue.empty():
+            try:
+                self._rx_queue.get_nowait()
+            except Empty:
+                break
+
+    @staticmethod
+    def _check_negative(payload: bytes, expected_resp_sid: int):
+        """Raise UDSError if the response is a negative (0x7F) reply."""
+        if len(payload) >= 3 and payload[0] == SID_NEGATIVE:
+            raise UDSError(
+                f"negative response: SID=0x{payload[1]:02X} "
+                f"NRC=0x{payload[2]:02X}",
+                sid=payload[1], nrc=payload[2],
+            )
+        if not payload or payload[0] != expected_resp_sid:
+            raise UDSError(
+                f"unexpected response SID 0x{payload[0]:02X} "
+                f"(expected 0x{expected_resp_sid:02X})"
+            )
+
+    # ── ReadDataByIdentifier (0x22) ───────────────────────────────────
+
+    def read_did(self, did: int) -> dict:
+        """Issue ReadDID(did) and return decoded fields.
+
+        Returns a dict shaped as
+            {
+              "did":     0xF101,
+              "did_hex": "0xF101",
+              "raw":     [data1..data5],
+              ... per-DID decoded fields ...
+            }
+        """
+        if not (0 <= did <= 0xFFFF):
+            raise ValueError(f"DID out of range: 0x{did:X}")
+        with self._req_lock:
+            self._drain_queue()
+            self._send_request(bytes([
+                SID_READ_DID,
+                (did >> 8) & 0xFF,
+                did & 0xFF,
+                0x00,
+            ]))
+            payload = self._wait_response()
+        self._check_negative(payload, SID_READ_DID_RESP)
+        # payload[1:3] echoes the DID
+        echoed_did = (payload[1] << 8) | payload[2]
+        if echoed_did != did:
+            raise UDSError(
+                f"response echoed DID 0x{echoed_did:04X} "
+                f"(requested 0x{did:04X})"
+            )
+        raw = list(payload[3:8])
+        result = {
+            "did":     did,
+            "did_hex": f"0x{did:04X}",
+            "raw":     raw,
+        }
+        result.update(_decode_did(did, raw))
+        return result
+
+    # ── ClearDiagnosticInformation (0x14) ─────────────────────────────
+
+    def clear_dtc(self) -> dict:
+        """Clear all DTCs (group 0xFFFFFF — all groups)."""
+        with self._req_lock:
+            self._drain_queue()
+            self._send_request(bytes([SID_CLEAR_DTC, 0xFF, 0xFF, 0xFF]))
+            payload = self._wait_response()
+        self._check_negative(payload, SID_CLEAR_DTC_RESP)
+        return {"ok": True, "raw": list(payload)}
+
+    # ── RoutineControl (0x31) ─────────────────────────────────────────
+
+    def routine_control(self, rid: int, value: int) -> dict:
+        """Send RoutineControl(rid, value).
+
+        For RID 0x0301 (AEB enable):
+            value=0 -> disable AEB
+            value=1 -> enable AEB
+        """
+        if not (0 <= rid <= 0xFFFF):
+            raise ValueError(f"RID out of range: 0x{rid:X}")
+        if not (0 <= value <= 0xFF):
+            raise ValueError(f"value out of range: {value}")
+        with self._req_lock:
+            self._drain_queue()
+            self._send_request(bytes([
+                SID_ROUTINE_CTRL,
+                (rid >> 8) & 0xFF,
+                rid & 0xFF,
+                value,
+            ]))
+            payload = self._wait_response()
+        self._check_negative(payload, SID_ROUTINE_RESP)
+        return {"ok": True, "rid": rid, "value": value, "raw": list(payload)}
+
+
+# ── DID-specific decoding helpers ─────────────────────────────────────────
+
+def _decode_did(did: int, raw: list) -> dict:
+    """Apply DID-specific physical decoding on top of raw bytes."""
+    if did == DID_TTC:
+        scaled = raw[0] | (raw[1] << 8)
+        return {"ttc_s": scaled / 100.0}
+    if did == DID_FSM_STATE:
+        state = raw[0]
+        return {
+            "fsm_state":      state,
+            "fsm_state_name": FSM_STATE_NAMES.get(state, "UNKNOWN"),
+        }
+    if did == DID_BRAKE_PRESS:
+        scaled = raw[0] | (raw[1] << 8)
+        return {"brake_pct": scaled / 10.0}
+    return {}

--- a/sil/docker/dashboard/index.html
+++ b/sil/docker/dashboard/index.html
@@ -439,6 +439,129 @@
             border-color: rgba(231, 76, 60, 0.6);
             display: block;
         }
+        /* ── UDS Diagnostic Panel (toggle from scenario bar) ─── */
+        .btn-uds {
+            background: #4d3d8a;
+            color: white;
+            border: 1px solid #6b5bb3;
+        }
+        .btn-uds:hover { background: #5e4ca0; }
+        .btn-uds.active { background: #7259d4; }
+
+        .uds-panel {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 340px;
+            background: rgba(13,17,23,0.96);
+            border-left: 1px solid #2d2748;
+            color: #e0e0e0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            box-shadow: -4px 0 12px rgba(0,0,0,0.4);
+            z-index: 30;
+            overflow-y: auto;
+            padding: 12px 14px;
+            transform: translateX(100%);
+            transition: transform 0.25s ease;
+        }
+        .uds-panel.open { transform: translateX(0); }
+        .uds-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 10px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #2d2748;
+        }
+        .uds-header .title {
+            font-size: 13px;
+            font-weight: bold;
+            color: #b0a8e8;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+        }
+        .uds-conn {
+            display: flex; align-items: center; gap: 6px;
+            font-size: 10px;
+            color: #888;
+        }
+        .uds-dot {
+            width: 8px; height: 8px; border-radius: 50%;
+            background: #555;
+        }
+        .uds-dot.ok   { background: #28a745; box-shadow: 0 0 6px #28a745; }
+        .uds-dot.err  { background: #dc3545; }
+        .uds-dot.idle { background: #888; }
+
+        .uds-cards {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+        .uds-card {
+            background: #141826;
+            border: 1px solid #232a3d;
+            border-radius: 6px;
+            padding: 8px 10px;
+        }
+        .uds-card .lbl {
+            font-size: 9px;
+            color: #6c7290;
+            letter-spacing: 0.6px;
+            text-transform: uppercase;
+        }
+        .uds-card .val {
+            font-size: 22px;
+            font-weight: bold;
+            font-family: 'Courier New', monospace;
+            color: #e0e0e0;
+            margin-top: 2px;
+        }
+        .uds-card .sub {
+            font-size: 10px;
+            color: #6c7290;
+            margin-top: 2px;
+        }
+        .uds-card.error .val { color: #dc3545; font-size: 13px; }
+
+        .uds-actions {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 12px;
+        }
+        .uds-btn {
+            padding: 8px 10px;
+            border-radius: 4px;
+            border: 1px solid #3a3658;
+            background: #1c1d2e;
+            color: #cfd0e0;
+            cursor: pointer;
+            font-size: 11px;
+            text-align: left;
+            transition: background 0.2s;
+        }
+        .uds-btn:hover { background: #262842; }
+        .uds-btn.toggle-on  { background: #1d3a26; border-color: #2d6a3a; color: #b8e8c4; }
+        .uds-btn.toggle-off { background: #3a1d1d; border-color: #6a2d2d; color: #e8b8b8; }
+
+        .uds-log {
+            background: #0a0d14;
+            border: 1px solid #1f2536;
+            border-radius: 4px;
+            padding: 6px 8px;
+            font-family: 'Courier New', monospace;
+            font-size: 10px;
+            color: #6c7290;
+            max-height: 140px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+        .uds-log .row-ok  { color: #6ec47e; }
+        .uds-log .row-err { color: #e07b7b; }
     </style>
 </head>
 <body>
@@ -456,10 +579,47 @@
             <button class="btn btn-go"   onclick="startScenario()">Start</button>
             <button class="btn btn-halt" onclick="stopScenario()">Stop</button>
             <button class="btn btn-redo" onclick="restartScenario()">Reset</button>
+            <button class="btn btn-uds" id="udsToggleBtn"
+                    onclick="toggleUdsPanel()">UDS</button>
             <span class="info" id="scenarioInfo"></span>
         </div>
 
         <div class="result-overlay" id="resultOverlay"></div>
+
+        <!-- ── UDS Diagnostic Panel (right, toggled by UDS button) ── -->
+        <aside class="uds-panel" id="udsPanel">
+            <div class="uds-header">
+                <span class="title">UDS Diagnostics</span>
+                <span class="uds-conn">
+                    <span class="uds-dot idle" id="udsDot"></span>
+                    <span id="udsConnLbl">--</span>
+                </span>
+            </div>
+
+            <div class="uds-cards">
+                <div class="uds-card" id="udsTtcCard">
+                    <div class="lbl">DID 0xF100 — TTC</div>
+                    <div class="val" id="udsTtc">-- s</div>
+                </div>
+                <div class="uds-card" id="udsFsmCard">
+                    <div class="lbl">DID 0xF101 — FSM state</div>
+                    <div class="val" id="udsFsm">--</div>
+                    <div class="sub" id="udsFsmSub"></div>
+                </div>
+                <div class="uds-card" id="udsBrakeCard">
+                    <div class="lbl">DID 0xF102 — Brake pressure</div>
+                    <div class="val" id="udsBrake">-- %</div>
+                </div>
+            </div>
+
+            <div class="uds-actions">
+                <button class="uds-btn toggle-on" id="udsAebBtn"
+                        onclick="udsToggleAeb()">AEB: enabled — click to disable</button>
+                <button class="uds-btn" onclick="udsClearDtc()">Clear DTCs (0x14)</button>
+            </div>
+
+            <div class="uds-log" id="udsLog">[idle]</div>
+        </aside>
     </div>
 
     <!-- ── Bottom: Car Dashboard ───────────────────────────────────────── -->
@@ -822,6 +982,7 @@ function resetDashboard() {
     updateAlerts(false, false);
     document.getElementById('distVal').textContent = '—';
     document.getElementById('tgtVal').textContent = '—';
+    resetFsmDebounce();   // clear any held-over FSM state from previous run
 }
 
 function setDot(status) {
@@ -837,6 +998,46 @@ const FSM_MAP = {
     'OFF': 0, 'STANDBY': 1, 'WARNING': 2,
     'BRAKE_L1': 3, 'BRAKE_L2': 4, 'BRAKE_L3': 5, 'POST_BRAKE': 6
 };
+const FSM_NAMES_BY_RAW = {
+    0: 'OFF', 1: 'STANDBY', 2: 'WARNING',
+    3: 'BRAKE_L1', 4: 'BRAKE_L2', 5: 'BRAKE_L3', 6: 'POST_BRAKE'
+};
+
+// ── FSM-state debounce ──────────────────────────────────────────────────
+// The Zephyr ECU briefly transitions to OFF (state 0) during scenario
+// startup (ECU container restart, ~2-3s of zero-CAN-data) and during
+// transient perception ROC faults (e.g., the velocity ramp at scenario
+// start kicks Δv_rel above VEL_ROC_LIMIT for ~30ms, latching fault for
+// ~3 cycles). Both manifest as visible flickers in the cascade pills /
+// UDS panel without indicating any real fault. We hold the last committed
+// non-OFF state for `holdMs` before committing OFF; persistent OFF
+// (AEB disabled, sensor fault) still surfaces after holdMs.
+const cascadeFsmCtx = { lastCommitted: 1, offSince: null };
+const udsFsmCtx     = { lastCommitted: 1, offSince: null };
+
+function fsmDebounce(rawState, ctx, holdMs) {
+    if (holdMs === undefined) holdMs = 500;
+    if (rawState !== 0) {
+        ctx.lastCommitted = rawState;
+        ctx.offSince = null;
+        return rawState;
+    }
+    // raw === 0 (OFF)
+    if (ctx.offSince === null) {
+        ctx.offSince = Date.now();
+        return ctx.lastCommitted;          // hide first OFF sample
+    }
+    if (Date.now() - ctx.offSince >= holdMs) {
+        ctx.lastCommitted = 0;
+        return 0;                          // OFF persisted long enough — commit
+    }
+    return ctx.lastCommitted;              // still within hold window
+}
+
+function resetFsmDebounce() {
+    cascadeFsmCtx.lastCommitted = 1; cascadeFsmCtx.offSince = null;
+    udsFsmCtx.lastCommitted     = 1; udsFsmCtx.offSince     = null;
+}
 
 async function tick() {
     try {
@@ -847,7 +1048,8 @@ async function tick() {
         const dist  = d.distance || 0;
         const brake = d.brake_pct || 0;
         const ttc   = d.ttc || 10;
-        const fsm   = FSM_MAP[d.fsm_state] !== undefined ? FSM_MAP[d.fsm_state] : 0;
+        const rawFsm = FSM_MAP[d.fsm_state] !== undefined ? FSM_MAP[d.fsm_state] : 0;
+        const fsm   = fsmDebounce(rawFsm, cascadeFsmCtx);
         const vis   = fsm >= 2 && fsm <= 5;
         const aud   = fsm >= 3 && fsm <= 5;
 
@@ -879,6 +1081,129 @@ async function tick() {
 loadScenarios();
 drawSpeedo(0);
 setInterval(tick, 100);
+
+// ═════════════════════════════════════════════════════════════════════════
+//  UDS Diagnostic Panel
+// ═════════════════════════════════════════════════════════════════════════
+
+const UDS_RID_AEB = 0x0301;
+let udsPanelOpen = false;
+let udsPollHandle = null;
+let udsAebEnabled = true;   // tracked locally; reflects last toggle
+
+function udsLog(msg, level) {
+    const log = document.getElementById('udsLog');
+    const ts  = new Date().toLocaleTimeString();
+    const cls = level === 'err' ? 'row-err' : 'row-ok';
+    const row = document.createElement('div');
+    row.className = cls;
+    row.textContent = `[${ts}] ${msg}`;
+    log.insertBefore(row, log.firstChild);
+    while (log.children.length > 30) log.removeChild(log.lastChild);
+}
+
+function udsSetDot(state) {
+    const d = document.getElementById('udsDot');
+    const l = document.getElementById('udsConnLbl');
+    d.classList.remove('ok', 'err', 'idle');
+    if (state === 'ok')   { d.classList.add('ok');   l.textContent = 'connected'; }
+    else if (state === 'err') { d.classList.add('err'); l.textContent = 'error'; }
+    else                  { d.classList.add('idle'); l.textContent = 'idle'; }
+}
+
+async function udsPollSnapshot() {
+    try {
+        const resp = await fetch(API + '/uds/snapshot');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const s = await resp.json();
+        udsSetDot('ok');
+
+        if (s.ttc && s.ttc.ttc_s !== undefined) {
+            document.getElementById('udsTtc').textContent =
+                s.ttc.ttc_s.toFixed(2) + ' s';
+            document.getElementById('udsTtcCard').classList.remove('error');
+        } else if (s.ttc && s.ttc.error) {
+            document.getElementById('udsTtc').textContent = s.ttc.error;
+            document.getElementById('udsTtcCard').classList.add('error');
+        }
+
+        if (s.fsm && s.fsm.fsm_state !== undefined) {
+            const rawFsm = s.fsm.fsm_state;
+            const debouncedFsm = fsmDebounce(rawFsm, udsFsmCtx);
+            document.getElementById('udsFsm').textContent =
+                FSM_NAMES_BY_RAW[debouncedFsm] || s.fsm.fsm_state_name;
+            document.getElementById('udsFsmSub').textContent =
+                'raw = ' + rawFsm;          // show the un-debounced value
+            document.getElementById('udsFsmCard').classList.remove('error');
+        } else if (s.fsm && s.fsm.error) {
+            document.getElementById('udsFsm').textContent = s.fsm.error;
+            document.getElementById('udsFsmCard').classList.add('error');
+        }
+
+        if (s.brake && s.brake.brake_pct !== undefined) {
+            document.getElementById('udsBrake').textContent =
+                s.brake.brake_pct.toFixed(1) + ' %';
+            document.getElementById('udsBrakeCard').classList.remove('error');
+        } else if (s.brake && s.brake.error) {
+            document.getElementById('udsBrake').textContent = s.brake.error;
+            document.getElementById('udsBrakeCard').classList.add('error');
+        }
+    } catch (e) {
+        udsSetDot('err');
+    }
+}
+
+function toggleUdsPanel() {
+    udsPanelOpen = !udsPanelOpen;
+    document.getElementById('udsPanel').classList.toggle('open', udsPanelOpen);
+    document.getElementById('udsToggleBtn').classList.toggle('active', udsPanelOpen);
+    if (udsPanelOpen) {
+        udsPollSnapshot();
+        udsPollHandle = setInterval(udsPollSnapshot, 200);  // 5 Hz
+    } else {
+        if (udsPollHandle) {
+            clearInterval(udsPollHandle);
+            udsPollHandle = null;
+        }
+        udsSetDot('idle');
+    }
+}
+
+async function udsClearDtc() {
+    try {
+        const r = await fetch(API + '/uds/clear_dtc', {method: 'POST'});
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        udsLog('clear_dtc -> ok', 'ok');
+    } catch (e) {
+        udsLog('clear_dtc -> ' + e, 'err');
+    }
+}
+
+async function udsToggleAeb() {
+    const next = udsAebEnabled ? 0 : 1;
+    try {
+        const r = await fetch(API + '/uds/routine_control', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({rid: UDS_RID_AEB, value: next}),
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        udsAebEnabled = (next === 1);
+        const btn = document.getElementById('udsAebBtn');
+        if (udsAebEnabled) {
+            btn.classList.remove('toggle-off');
+            btn.classList.add('toggle-on');
+            btn.textContent = 'AEB: enabled — click to disable';
+        } else {
+            btn.classList.remove('toggle-on');
+            btn.classList.add('toggle-off');
+            btn.textContent = 'AEB: DISABLED — click to enable';
+        }
+        udsLog('routine_ctrl(0x0301, ' + next + ') -> ok', 'ok');
+    } catch (e) {
+        udsLog('routine_ctrl -> ' + e, 'err');
+    }
+}
 </script>
 
 </body>


### PR DESCRIPTION
# Summary

- Adds the **UDS Diagnostic scenario** to the SIL: Python TCP-CAN client (`uds_client.py`), five REST endpoints in the FastAPI app (`/uds/health`, `/uds/read_did/{did}`, `/uds/snapshot`, `/uds/clear_dtc`, `/uds/routine_control`), a slide-in dashboard panel that polls live DIDs at 5 Hz and exposes Clear-DTC + AEB enable/disable, plus the `uds_diagnostic` scenario entry.
- Adds a **`ccrs_50_no_aeb` control scenario** that fires UDS RoutineControl(0x0301, 0) right after the ECU restart, so the FSM stays in OFF for the entire run — useful as a comparison-with-AEB baseline.
- Adds an **FSM-state debounce** in the dashboard frontend (cascade pills + UDS panel) that holds the last committed non-OFF state for 500 ms before surfacing OFF. Filters transient flickers (perception ROC during velocity ramp, ECU restart settle) without hiding persistent OFF (AEB disabled, real sensor fault).
- 15 unit tests for `uds_client.py` driven against a local fake TCP relay, covering wire-level encoding/decoding, negative responses, timeouts, DID-echo mismatches, and concurrent request serialisation. All green locally.

# Related Issue

Builds on #97 (UDS over CAN in production C — already merged into `development`). Branched off `feat/sil-gazebo-docker` (PR #120).

# Change Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] test
- [ ] ci
- [ ] refactor/chore

# AEB Areas Affected

- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [x] UDS Diagnostics
- [x] Integration

# Requirements Impacted

## Functional Requirements

- **FR-UDS-001 / 003 / 004 / 005** — surfaces the production C UDS server end-to-end via HTTP. Request and response stay on the production side; this PR adds the *consumer* path: dashboard → FastAPI → TCP-CAN relay → ECU on `0x7DF`/`0x7E8`.

## Non-Functional Requirements

- **NFR-VAL-005** — adds a manually-triggered SIL scenario for diagnostic verification, complementing the Euro NCAP CCRs/CCRm/CCRb scenarios.

# Artifacts Updated

- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [x] C source code
- [x] Tests
- [ ] CI workflow
- [x] README / SCM documentation
- [ ] CHANGELOG

(C source code box ticked because the new SIL UDS path exercises FR-UDS-005 end-to-end against unmodified production C.)

# Validation Evidence

- [x] Local build passes
- [x] Automated tests pass
- [x] Live SIL stack walkthrough completed
- [ ] CI passes *(no SIL-specific workflow exists yet)*
- [x] Traceability preserved
- [x] Safety-relevant impact assessed
- [x] Documentation updated

## Evidence

**Unit tests**

```
$ cd sil/docker/api && python -m pytest tests/ -v
============================ 15 passed in 0.48s =============================
```

**Live SIL stack walkthrough**

`docker compose up --build` brought up canbus + gazebo + aeb-ecu + api + dashboard. Verified:

- `/uds/health` → connected
- `uds_diagnostic` scenario → ego stationary, dashboard's UDS panel polls TTC=10.0s, FSM_STATE=STANDBY, brake=0% live at 5 Hz
- `ccrs_50_no_aeb` scenario → ECU restart + UDS RoutineControl(0x0301, 0) → FSM stays in OFF the whole run, ego closes on target with no AEB intervention (control case)
- `ccrs_50` scenario (AEB enabled) → FSM cascade STANDBY → WARNING → BRAKE_L1/L2/L3 → POST_BRAKE observed live in both the cascade pills AND the UDS panel
- Clear DTCs (0x14) and AEB enable/disable toggle exercised — log row colour-coded green for success
- Negative-response paths exercised (e.g., requesting an unsupported DID) → red log row, panel stays alive

**Frame-format compatibility verified**: `uds_client.py` 16-byte `<IBxxx><8B>` matches `sil/docker/canbus/can_tcp_server.py:FRAME_SIZE = 16`.

**Affected scenarios**: none of CCRs/CCRm/CCRb altered. Two new scenarios:
- `uds_diagnostic` — quiescent baseline with ego stationary; demo flow for UDS panel.
- `ccrs_50_no_aeb` — identical to ccrs_50 but `disable_aeb: true` flag triggers UDS-driven AEB disable on scenario start. The control case for "what would happen without AEB" comparisons.

# Reviewer Notes

Three things worth focusing on:

1. **Frame-format compatibility with `canbus`.** `uds_client.py` uses the same 16-byte `<IBxxx><8B>` layout as `sil/docker/canbus/can_tcp_server.py` and `sil/aeb_gazebo/src/can_tcp_client.py`. Confirm the layout in `_send_request` (line ~120 of `uds_client.py`) matches the relay's `_pack_frame`.

2. **Lazy UDS client construction in `scenario_api.py`.** `_get_uds_client()` defers the TCP connection until the first `/uds/*` request to avoid blocking app startup when the canbus container is still coming up. Connection errors return HTTP 503 and the next request will retry.

3. **`disable_aeb` flag in scenarios.yaml + `/scenarios/start` UDS hook.** The flag fires UDS RoutineControl(0x0301, 0) **after** `restart_aeb_ecu()` returns, because UDS state on the Zephyr ECU is RAM-only and a fresh container always boots with `aeb_enabled = 1` (per `aeb_core_init` in `aeb_core.c`). Other scenarios are unaffected — only those with the YAML opt-in get the disable.

4. **FSM-state debounce in `index.html`** (the `fsmDebounce` helper). Filters sub-500 ms OFF flickers from perception ROC during velocity ramp and ECU restart settle, *without* hiding persistent OFF. The "raw = N" subtitle on the UDS panel's FSM card always shows the un-debounced ECU value for debugging.

# Risks / Open Points

1. **No SIL CI workflow exists** — the unit tests for `uds_client.py` will be picked up if/when a SIL workflow is added; today they are run-locally only.

2. **Dashboard FSM debounce is presentation-layer only** — the underlying `/live` and `/uds/snapshot` payloads still carry the raw ECU state. Anything reading those endpoints programmatically (test scripts, external tools) sees the un-debounced values. Document this in the API contract if/when one is published.

3. **`disable_aeb` flag is currently honoured on `/scenarios/start` only** — `/scenarios/restart` does not re-fire the disable, so a Restart click on `ccrs_50_no_aeb` would resurrect AEB. Easy follow-up; not on the critical path.

4. **`ccrs_50_no_aeb` always collides at 50 km/h** — that's the expected control behaviour, but the dashboard's collision banner ("STOPPED · gap N m") doesn't fire for collision events; only for stops. UI nicety, not a functional issue.

5. **CCRb_d6_g40 unchanged** — still collides at 19.7 km/h with AEB enabled (carried over from PR #120). FSM-tuning conversation, separate from UDS scope.

This PR is ready for review.
