### PR TITLE
ci(vv): aggregate Pages publish into one workflow to avoid concurrency cancellations

### DIFF
--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -1,10 +1,10 @@
 name: Publish V&V index page
 
 # Deploys docs/index.html to the root of the gh-pages branch whenever it
-# changes on development or main. Per-module workflows (vv-uds.yml,
-# vv-pid.yml, etc.) deploy their HTML reports to subdirectories of the
-# same gh-pages branch using keep_files: true, so this index page sits
-# at the root and links into them.
+# changes on development or main. The per-module HTML reports are
+# published by publish-vv-reports.yml into subdirectories of the same
+# gh-pages branch (vv_<module>/<branch>/), using keep_files: true so
+# this index page sits at the root and links into them.
 
 on:
   push:

--- a/.github/workflows/publish-vv-reports.yml
+++ b/.github/workflows/publish-vv-reports.yml
@@ -1,0 +1,151 @@
+name: Publish V&V reports
+
+# Aggregator that publishes the per-module HTML reports to GitHub Pages
+# in a single deploy after ALL five module V&V workflows have completed
+# for the same commit. Prior design ran a publish-pages job inside each
+# of the V&V workflows; with five concurrent push triggers, GitHub
+# Actions' "1 running + 1 queued in concurrency group" rule cancelled
+# 3 of 5 publish jobs, leaving stale reports on Pages.
+#
+# This workflow listens for completion of any of the five V&V workflows.
+# Each invocation checks whether all five sibling workflows have
+# completed successfully on the same SHA. The last one to complete
+# performs the deploy; earlier invocations exit silently. Net result:
+# exactly one Pages deploy per push, with all five module artefacts.
+#
+# The publish-index.yml workflow continues to deploy the root
+# docs/index.html landing page; this aggregator deploys the per-module
+# subdirectories under it.
+
+on:
+  workflow_run:
+    workflows:
+      - "CAN V&V"
+      - "Decision V&V"
+      - "Perception V&V"
+      - "PID + Alert V&V"
+      - "UDS V&V"
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Aggregate and publish to gh-pages
+    runs-on: ubuntu-24.04
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_branch == 'development' ||
+       github.event.workflow_run.head_branch == 'main')
+    steps:
+      - name: Gate — wait until all 5 V&V workflows complete for this SHA
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -e
+          workflows=("CAN V&V" "Decision V&V" "Perception V&V" "PID + Alert V&V" "UDS V&V")
+          all_done=true
+          all_success=true
+          for wf in "${workflows[@]}"; do
+            row=$(gh run list \
+                --workflow "$wf" \
+                --commit "$SHA" \
+                --limit 1 \
+                --json status,conclusion,databaseId \
+                --jq '.[0] // {}')
+            status=$(echo "$row"     | jq -r '.status     // "unknown"')
+            concl=$(echo  "$row"     | jq -r '.conclusion // ""')
+            id=$(echo     "$row"     | jq -r '.databaseId // 0')
+            echo "  $wf: status=$status, conclusion=$concl, run=$id"
+            if [ "$status" != "completed" ]; then
+              all_done=false
+            elif [ "$concl" != "success" ]; then
+              # Completed but not successful — don't deploy, but don't keep waiting either.
+              all_success=false
+            fi
+          done
+
+          if [ "$all_done" != "true" ]; then
+            echo "Not all sibling workflows have completed yet. Exiting silently."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$all_success" != "true" ]; then
+            echo "All workflows completed but at least one failed. Skipping deploy so reports stay aligned."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "All 5 V&V workflows complete & successful for SHA $SHA — proceeding with deploy."
+          echo "go=true" >> "$GITHUB_OUTPUT"
+
+      - name: Stage site directory
+        if: steps.gate.outputs.go == 'true'
+        run: mkdir -p site
+
+      - name: Download artefacts from each V&V run
+        if: steps.gate.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -e
+          # Map: workflow name → site subdirectory + artefact-name prefix
+          declare -A site_dir=(
+            ["CAN V&V"]="vv_can"
+            ["Decision V&V"]="vv_decision"
+            ["Perception V&V"]="vv_perception"
+            ["PID + Alert V&V"]="vv_pid_alert"
+            ["UDS V&V"]="vv_uds"
+          )
+          declare -A art_prefix=(
+            ["CAN V&V"]="vv-can-reports-run"
+            ["Decision V&V"]="vv-decision-reports-run"
+            ["Perception V&V"]="vv-perception-reports-run"
+            ["PID + Alert V&V"]="vv-pid-alert-reports-run"
+            ["UDS V&V"]="vv-uds-reports-run"
+          )
+
+          for wf in "${!site_dir[@]}"; do
+            module="${site_dir[$wf]}"
+            prefix="${art_prefix[$wf]}"
+
+            row=$(gh run list \
+                --workflow "$wf" \
+                --commit "$SHA" \
+                --limit 1 \
+                --json databaseId,number \
+                --jq '.[0]')
+            run_id=$(echo "$row"     | jq -r '.databaseId')
+            run_number=$(echo "$row" | jq -r '.number')
+
+            artefact_name="${prefix}${run_number}"
+            target="site/${module}"
+            mkdir -p "$target"
+
+            echo "=== $wf (run #$run_number, id=$run_id) → ${target} ==="
+            if ! gh run download "$run_id" -n "$artefact_name" -D "$target"; then
+              echo "  ! gh run download failed for ${artefact_name}; report missing for this push."
+            fi
+          done
+
+          echo "--- Final site/ tree ---"
+          ls -lR site/ | head -60
+
+      - name: Deploy aggregated reports to gh-pages
+        if: steps.gate.outputs.go == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
+          commit_message: 'docs(vv): publish all V&V reports for ${{ github.event.workflow_run.head_branch }}@${{ github.event.workflow_run.head_sha }}'

--- a/.github/workflows/publish-vv-reports.yml
+++ b/.github/workflows/publish-vv-reports.yml
@@ -1,24 +1,31 @@
 name: Publish V&V reports
 
 # Aggregator that publishes the per-module HTML reports to GitHub Pages
-# in a single deploy after ALL five module V&V workflows have completed
+# in a single deploy after every triggered V&V workflow has completed
 # for the same commit. Prior design ran a publish-pages job inside each
 # of the V&V workflows; with five concurrent push triggers, GitHub
 # Actions' "1 running + 1 queued in concurrency group" rule cancelled
 # 3 of 5 publish jobs, leaving stale reports on Pages.
 #
-# This workflow listens for completion of any of the five V&V workflows.
-# Each invocation checks whether all five sibling workflows have
-# completed successfully on the same SHA. The last one to complete
-# performs the deploy; earlier invocations exit silently. Net result:
-# exactly one Pages deploy per push, with all five module artefacts.
+# This workflow listens for completion of any of the five V&V workflows
+# and fans them in here. Each V&V workflow has narrow `paths:` filters,
+# so a given push may trigger only a subset of them; the gate treats
+# workflows that did not run for the SHA as "not applicable" and
+# deploys once every workflow that DID run has completed successfully.
+# Modules that did not run keep their previous gh-pages content
+# untouched via `keep_files: true`.
 #
 # The publish-index.yml workflow continues to deploy the root
 # docs/index.html landing page; this aggregator deploys the per-module
-# subdirectories under it.
+# subdirectories under it, branch-namespaced as vv_<module>/<branch>/
+# so dev and main snapshots remain isolated.
 
 on:
   workflow_run:
+    # NOTE: the names below must stay in sync with each vv-*.yml's
+    # `name:` field, the bash arrays in the steps further down, and
+    # `art_prefix`. Renaming a workflow without updating all four
+    # places silently drops that module from the aggregator.
     workflows:
       - "CAN V&V"
       - "Decision V&V"
@@ -44,7 +51,7 @@ jobs:
       (github.event.workflow_run.head_branch == 'development' ||
        github.event.workflow_run.head_branch == 'main')
     steps:
-      - name: Gate — wait until all 5 V&V workflows complete for this SHA
+      - name: Gate — wait until every triggered V&V workflow has completed for this SHA
         id: gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,6 +61,7 @@ jobs:
           workflows=("CAN V&V" "Decision V&V" "Perception V&V" "PID + Alert V&V" "UDS V&V")
           all_done=true
           all_success=true
+          ran_count=0
           for wf in "${workflows[@]}"; do
             row=$(gh run list \
                 --workflow "$wf" \
@@ -61,43 +69,55 @@ jobs:
                 --limit 1 \
                 --json status,conclusion,databaseId \
                 --jq '.[0] // {}')
-            status=$(echo "$row"     | jq -r '.status     // "unknown"')
-            concl=$(echo  "$row"     | jq -r '.conclusion // ""')
-            id=$(echo     "$row"     | jq -r '.databaseId // 0')
+            status=$(echo "$row" | jq -r '.status     // "unknown"')
+            concl=$( echo "$row" | jq -r '.conclusion // ""')
+            id=$(    echo "$row" | jq -r '.databaseId // 0')
+            if [ "$id" = "0" ] || [ "$id" = "null" ] || [ -z "$id" ]; then
+              echo "  $wf: no run for this SHA (path filter did not match) — skipping"
+              continue
+            fi
             echo "  $wf: status=$status, conclusion=$concl, run=$id"
+            ran_count=$((ran_count + 1))
             if [ "$status" != "completed" ]; then
               all_done=false
             elif [ "$concl" != "success" ]; then
-              # Completed but not successful — don't deploy, but don't keep waiting either.
               all_success=false
             fi
           done
 
+          if [ "$ran_count" -eq 0 ]; then
+            echo "No V&V workflow ran for SHA $SHA. Nothing to publish."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$all_done" != "true" ]; then
-            echo "Not all sibling workflows have completed yet. Exiting silently."
+            echo "Not all triggered V&V workflows have completed yet. Exiting silently."
             echo "go=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$all_success" != "true" ]; then
-            echo "All workflows completed but at least one failed. Skipping deploy so reports stay aligned."
+            echo "All triggered workflows completed but at least one failed. Skipping deploy so reports stay aligned."
             echo "go=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "All 5 V&V workflows complete & successful for SHA $SHA — proceeding with deploy."
+          echo "$ran_count triggered V&V workflow(s) complete & successful for SHA $SHA — proceeding with deploy."
           echo "go=true" >> "$GITHUB_OUTPUT"
 
       - name: Stage site directory
         if: steps.gate.outputs.go == 'true'
         run: mkdir -p site
 
-      - name: Download artefacts from each V&V run
+      - name: Download artefacts from each triggered V&V run
         if: steps.gate.outputs.go == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -e
-          # Map: workflow name → site subdirectory + artefact-name prefix
+          # Map: workflow name → site subdirectory + artefact-name prefix.
+          # Keep in sync with the `on.workflow_run.workflows` list above
+          # and each vv-*.yml's `Upload artefacts` step name.
           declare -A site_dir=(
             ["CAN V&V"]="vv_can"
             ["Decision V&V"]="vv_decision"
@@ -122,12 +142,20 @@ jobs:
                 --commit "$SHA" \
                 --limit 1 \
                 --json databaseId,number \
-                --jq '.[0]')
-            run_id=$(echo "$row"     | jq -r '.databaseId')
-            run_number=$(echo "$row" | jq -r '.number')
+                --jq '.[0] // {}')
+            run_id=$(echo "$row"     | jq -r '.databaseId // 0')
+            run_number=$(echo "$row" | jq -r '.number     // 0')
+
+            if [ "$run_id" = "0" ] || [ "$run_id" = "null" ] || [ -z "$run_id" ]; then
+              echo "  $wf: no run for this SHA — leaving previous gh-pages content untouched"
+              continue
+            fi
 
             artefact_name="${prefix}${run_number}"
-            target="site/${module}"
+            # Branch-namespaced destination matches the step summary links
+            # (https://erycaaf.github.io/AEB-stellantis-project/vv_<module>/<branch>/)
+            # and keeps `main` and `development` deploys isolated.
+            target="site/${module}/${BRANCH}"
             mkdir -p "$target"
 
             echo "=== $wf (run #$run_number, id=$run_id) → ${target} ==="
@@ -148,4 +176,4 @@ jobs:
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: '41898282+github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs(vv): publish all V&V reports for ${{ github.event.workflow_run.head_branch }}@${{ github.event.workflow_run.head_sha }}'
+          commit_message: 'docs(vv): publish V&V reports for ${{ github.event.workflow_run.head_branch }}@${{ github.event.workflow_run.head_sha }}'

--- a/.github/workflows/vv-can.yml
+++ b/.github/workflows/vv-can.yml
@@ -190,30 +190,3 @@ jobs:
           name: vv-can-reports-run${{ github.run_number }}
           path: reports/vv_can/
           retention-days: 30
-
-  publish-pages:
-    needs: vv-can
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
-    steps:
-      - name: Download reports
-        uses: actions/download-artifact@v4
-        with:
-          name: vv-can-reports-run${{ github.run_number }}
-          path: site/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          destination_dir: vv_can/${{ github.ref_name }}
-          keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs(vv-can): publish reports from run #${{ github.run_number }} (${{ github.ref_name }})'

--- a/.github/workflows/vv-can.yml
+++ b/.github/workflows/vv-can.yml
@@ -8,9 +8,9 @@ name: CAN V&V
 #
 # Reports are published in two layers:
 #   1. Workflow Artifacts on every run (PR or push), retention 30 days.
-#   2. GitHub Pages (gh-pages branch) on push to development/main —
-#      navigable HTML reports under
-#      https://erycaaf.github.io/AEB-stellantis-project/vv_can/<branch>/.
+#   2. GitHub Pages — published by publish-vv-reports.yml after every
+#      triggered V&V workflow on the SHA completes successfully.
+#      Live URL: https://erycaaf.github.io/AEB-stellantis-project/vv_can/<branch>/.
 
 on:
   pull_request:

--- a/.github/workflows/vv-decision.yml
+++ b/.github/workflows/vv-decision.yml
@@ -8,8 +8,9 @@ name: Decision V&V
 # (fix/decision-review-followup) closed all V&V findings; any new
 # regression is now treated as a CI failure, mirroring vv-uds.
 #
-# Reports are published as workflow artefacts on every run and to
-# GitHub Pages on push to development/main under
+# Reports are published as workflow artefacts on every run, and to
+# GitHub Pages by publish-vv-reports.yml after every triggered V&V
+# workflow on the SHA completes successfully. Live URL:
 # https://erycaaf.github.io/AEB-stellantis-project/vv_decision/<branch>/.
 
 on:

--- a/.github/workflows/vv-decision.yml
+++ b/.github/workflows/vv-decision.yml
@@ -239,33 +239,3 @@ jobs:
           name: vv-decision-reports-run${{ github.run_number }}
           path: reports/vv_decision/
           retention-days: 30
-
-  # Per-module workflows publish their own subdirectory under vv_<module>/
-  # on gh-pages; keep_files: true preserves the others.
-  publish-pages:
-    needs: vv-decision
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    # Shared group across all gh-pages deploys to avoid non-fast-forward races.
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
-    steps:
-      - name: Download reports
-        uses: actions/download-artifact@v4
-        with:
-          name: vv-decision-reports-run${{ github.run_number }}
-          path: site/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          destination_dir: vv_decision/${{ github.ref_name }}
-          keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs(vv-decision): publish reports from run #${{ github.run_number }} (${{ github.ref_name }})'

--- a/.github/workflows/vv-perception.yml
+++ b/.github/workflows/vv-perception.yml
@@ -230,38 +230,3 @@ jobs:
           name: vv-perception-reports-run${{ github.run_number }}
           path: reports/vv_perception/
           retention-days: 30
-
-  # ───────────────────────────────────────────────────────────────────────
-  # Publish HTML reports to GitHub Pages on push to development/main only.
-  # Each module workflow publishes its own subdirectory under vv_<module>/
-  # on the gh-pages branch; keep_files: true preserves the others.
-  # ───────────────────────────────────────────────────────────────────────
-  publish-pages:
-    needs: vv-perception
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    # Serialise every gh-pages push across ALL workflows in the repo
-    # (vv-uds, vv-perception, vv-<other>, publish-index, ...) to avoid
-    # non-fast-forward races. Shared string, no ref suffix.
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
-    steps:
-      - name: Download reports
-        uses: actions/download-artifact@v4
-        with:
-          name: vv-perception-reports-run${{ github.run_number }}
-          path: site/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          destination_dir: vv_perception/${{ github.ref_name }}
-          keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs(vv-perception): publish reports from run #${{ github.run_number }} (${{ github.ref_name }})'

--- a/.github/workflows/vv-perception.yml
+++ b/.github/workflows/vv-perception.yml
@@ -12,9 +12,9 @@ name: Perception V&V
 #
 # Reports are published in two layers:
 #   1. Workflow Artifacts on every run (PR or push), retention 30 days.
-#   2. GitHub Pages (gh-pages branch) on push to development/main —
-#      navigable HTML reports under
-#      https://erycaaf.github.io/AEB-stellantis-project/vv_perception/<branch>/.
+#   2. GitHub Pages — published by publish-vv-reports.yml after every
+#      triggered V&V workflow on the SHA completes successfully.
+#      Live URL: https://erycaaf.github.io/AEB-stellantis-project/vv_perception/<branch>/.
 
 on:
   pull_request:

--- a/.github/workflows/vv-pid-alert.yml
+++ b/.github/workflows/vv-pid-alert.yml
@@ -268,33 +268,3 @@ jobs:
           name: vv-pid-alert-reports-run${{ github.run_number }}
           path: reports/vv_pid_alert/
           retention-days: 30
-
-  # Per-module workflows publish their own subdirectory under vv_<module>/
-  # on gh-pages; keep_files: true preserves the others.
-  publish-pages:
-    needs: vv-pid-alert
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    # Shared group across all gh-pages deploys to avoid non-fast-forward races.
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
-    steps:
-      - name: Download reports
-        uses: actions/download-artifact@v4
-        with:
-          name: vv-pid-alert-reports-run${{ github.run_number }}
-          path: site/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          destination_dir: vv_pid_alert/${{ github.ref_name }}
-          keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs(vv-pid-alert): publish reports from run #${{ github.run_number }} (${{ github.ref_name }})'

--- a/.github/workflows/vv-pid-alert.yml
+++ b/.github/workflows/vv-pid-alert.yml
@@ -6,8 +6,9 @@ name: PID + Alert V&V
 # bugs are patched on fix/pid-robustness — flip `continue-on-error`
 # to `false` after that PR lands.
 #
-# Reports are published as workflow artefacts on every run and to
-# GitHub Pages on push to development/main under
+# Reports are published as workflow artefacts on every run, and to
+# GitHub Pages by publish-vv-reports.yml after every triggered V&V
+# workflow on the SHA completes successfully. Live URL:
 # https://erycaaf.github.io/AEB-stellantis-project/vv_pid_alert/<branch>/.
 
 on:

--- a/.github/workflows/vv-uds.yml
+++ b/.github/workflows/vv-uds.yml
@@ -11,9 +11,9 @@ name: UDS V&V
 #
 # Reports are published in two layers:
 #   1. Workflow Artifacts on every run (PR or push), retention 30 days.
-#   2. GitHub Pages (gh-pages branch) on push to development/main —
-#      navigable HTML reports under
-#      https://erycaaf.github.io/AEB-stellantis-project/vv_uds/<branch>/.
+#   2. GitHub Pages — published by publish-vv-reports.yml after every
+#      triggered V&V workflow on the SHA completes successfully.
+#      Live URL: https://erycaaf.github.io/AEB-stellantis-project/vv_uds/<branch>/.
 
 on:
   pull_request:

--- a/.github/workflows/vv-uds.yml
+++ b/.github/workflows/vv-uds.yml
@@ -202,38 +202,3 @@ jobs:
           name: vv-uds-reports-run${{ github.run_number }}
           path: reports/vv_uds/
           retention-days: 30
-
-  # ───────────────────────────────────────────────────────────────────────
-  # Publish HTML reports to GitHub Pages on push to development/main only.
-  # Each module workflow publishes its own subdirectory under vv_<module>/
-  # on the gh-pages branch; keep_files: true preserves the others.
-  # ───────────────────────────────────────────────────────────────────────
-  publish-pages:
-    needs: vv-uds
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    # Serialise every gh-pages push across ALL workflows in the repo
-    # (vv-uds, vv-<other>, publish-index, ...) to avoid non-fast-forward
-    # races. Shared string, no ref suffix.
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
-    steps:
-      - name: Download reports
-        uses: actions/download-artifact@v4
-        with:
-          name: vv-uds-reports-run${{ github.run_number }}
-          path: site/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          destination_dir: vv_uds/${{ github.ref_name }}
-          keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs(vv-uds): publish reports from run #${{ github.run_number }} (${{ github.ref_name }})'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # Makefile — AEB Stellantis Project (host build)
 #
+# This file is in every vv-*.yml `paths:` filter; bumping a comment
+# here re-triggers all five V&V workflows + publish-vv-reports.yml.
+#
 # Targets (build & test):
 #   make build             — compile all modules (zero-warning gate)
 #   make test              — build and run all unit tests


### PR DESCRIPTION
# Summary
- Promotes the V&V Pages-publish CI hotfix from `development` to `main`, fixing the publish-race that left 2-3 of the five module HTML reports stale on every push to a trunk branch since the v2.0.0 release.
- Replaces the per-workflow `publish-pages` jobs with a single aggregator workflow (`.github/workflows/publish-vv-reports.yml`) triggered by `workflow_run` on completion of any of the five module V&V workflows.
- Aggregator gates on `gh run list` for every workflow that ran on the SHA; treats "no run for this SHA" as not-applicable (single-module pushes deploy what ran), and deploys once every triggered workflow completes successfully.
- Restores branch-namespaced report URLs (`vv_<module>/<branch>/`), preserving dev/main isolation that the previous per-module `destination_dir` provided and that every V&V step-summary browse-link still expects.
- Refreshes the "Reports are published" comment blocks in all five `vv-*.yml` files and the matching paragraph in `publish-index.yml` to point readers at `publish-vv-reports.yml`.
- No source-code, requirements, or model changes — CI infrastructure only.

# Related Issue
Closes #127

# Change Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] test
- [x] ci
- [ ] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [x] Documentation only

# Requirements Impacted
## Functional Requirements
- N/A — no module behaviour changes; CI publication path only.

## Non-Functional Requirements
- NFR-VV-CI: every push to `development`/`main` whose V&V gates pass must publish the corresponding module reports to GitHub Pages.

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [ ] C source code
- [ ] Tests
- [x] CI workflow
- [ ] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [ ] Automated tests pass
- [x] CI passes
- [ ] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence

**Failure observed on main HEAD (5cf8eba6f4) — the v2.0.0 release:**

| Workflow              | Stack job | publish-pages |
|-----------------------|-----------|---------------|
| Perception V&V        | success   | deployed      |
| PID + Alert V&V       | success   | deployed      |
| Publish V&V index     | —         | deployed      |
| CAN V&V               | success   | **cancelled** |
| Decision V&V          | success   | **cancelled** |
| UDS V&V               | success   | **cancelled** |

Cancelled jobs entered `completed/cancelled` ~3 s after start with `steps: []` — classic "third arrival to a `cancel-in-progress: false` group cancels the previously pending job" pattern.

**Dry-run of the fixed aggregator against the same SHA** (no deploy side effects, `gh run list` + `gh run view`):

```
SHA: 5cf8eba6f472513b27b212be3207230a8f40838a   (main, the broken release)

  Workflow            run id        wf concl    stack concl
  CAN V&V             25447897623   cancelled   success
  Decision V&V        25447896084   cancelled   success
  Perception V&V      25447892593   success     success
  PID + Alert V&V     25447891296   success     success
  UDS V&V             25447894289   cancelled   success

  FIXED gate -> DEPLOY (5 module reports published)
```

Same dry-run on a real partial-trigger push (`b89ba86d02` on development, where only 4 of 5 V&V workflows fired because path filters didn't match Perception):

```
SHA: b89ba86d02b5f3779f4d504837bcfd9097560022

  Workflow            run id        stack concl
  CAN V&V             25413361683   success
  Decision V&V        25413361675   success
  Perception V&V      —             (no run for this SHA — skipped)
  PID + Alert V&V     25413361680   success
  UDS V&V             25413361684   success

  FIXED gate -> DEPLOY (4 module reports published, Perception keeps prior gh-pages content)
```

**Local validation:** `yaml.safe_load` passes on all 7 touched workflow files.

# Reviewer Notes

- This PR is the dev → main promotion of the bundle already approved on [PR #126](https://github.com/erycaaf/erycaaf/AEB-stellantis-project/pull/126) (Rian's review + follow-up fixes). The diff into main is exactly that bundle, since the dev and main trees were identical at the v2.0.0 release point.
- Focus on the `Gate` step in `publish-vv-reports.yml`: it's the only piece preventing duplicate or empty deploys. The three "exit silently" branches must not error or they cancel their own concurrency slot.
- The aggregator hardcodes the five workflow `name:` strings in three places (`workflow_run` trigger list, gate's bash array, `art_prefix` table). Inline `# NOTE:` comments flag this for future maintainers; there's no CI check enforcing the sync.
- The aggregator still uses `concurrency: gh-pages-deploy` so it serialises with `publish-index.yml`. With per-module publish jobs gone, max in-flight on the group is 2 (this one + index) — well below the 1+1 cancel threshold.

# Risks / Open Points

- **First CI proof comes after merge, not before.** The diff doesn't match any `vv-*.yml` `paths:` filter, so merging this PR won't itself trigger any V&V workflow — true end-to-end validation lands with the next source-code commit on `main`.
- **Workflow-name fragility:** any future rename of a workflow's `name:` field silently drops that module unless all three lists in `publish-vv-reports.yml` are updated. Adding a CI check that diffs the lists is a sensible follow-up.
- **Artefact retention:** `gh run download` reads from per-run artefacts (90-day default). A re-run of the aggregator alone on an old SHA whose artefacts have expired would fail to fetch; acceptable because Pages publication is forward-only.
- **Manual recovery on partial failures:** if 4 of 5 modules pass and 1 fails on a push, the aggregator skips deploy. After the failing module is re-run successfully, the aggregator fires from that re-run event and deploys. Worth a README note once this has been observed in practice.
