### PR TITLE
chore(vv): trigger V&V workflows to repopulate gh-pages snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # Makefile — AEB Stellantis Project (host build)
 #
+# This file is in every vv-*.yml `paths:` filter; bumping a comment
+# here re-triggers all five V&V workflows + publish-vv-reports.yml.
+#
 # Targets (build & test):
 #   make build             — compile all modules (zero-warning gate)
 #   make test              — build and run all unit tests


### PR DESCRIPTION
# Summary
- Adds a three-line comment block to the top of the `Makefile` — no behavioural change, no impact on build or runtime.
- The Makefile is in every `vv-*.yml` `paths:` filter, so the merge commit fires all five V&V workflows.
- With `publish-vv-reports.yml` already on `development` (from PR #126), the aggregator fans the five completions into a single gh-pages deploy commit refreshing `vv_<module>/development/` for every module. Last refresh on Pages was 2026-05-06, before the publish-pages race fix landed.
- This same commit, carried forward in the upcoming `development → main` PR, will trigger the equivalent fan-in on `main` and finally populate `vv_can/main/`, `vv_decision/main/`, and `vv_uds/main/` — which have been 404 since the v2.0.0 release because their per-module `publish-pages` jobs lost the concurrency race on every push.

# Related Issue
Closes part of #127 (the dev → main PR closes the rest).

# Change Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] test
- [ ] ci
- [x] refactor/chore

# AEB Areas Affected
- [ ] Perception
- [ ] Decision Logic
- [ ] Driver Alerts
- [ ] Braking Control
- [ ] State Machine
- [ ] CAN Interface
- [ ] UDS Diagnostics
- [ ] Integration
- [x] Documentation only

# Requirements Impacted
## Functional Requirements
- N/A — comment-only change.

## Non-Functional Requirements
- NFR-VV-CI: re-validates the new aggregator on `development` in production CI, ahead of promoting it to `main`.

# Artifacts Updated
- [ ] Requirements document
- [ ] Modeling document
- [ ] Simulink / Stateflow model
- [ ] C source code
- [ ] Tests
- [ ] CI workflow
- [x] README / SCM documentation
- [ ] CHANGELOG

# Validation Evidence
- [x] Local build passes
- [ ] Automated tests pass
- [ ] CI passes
- [ ] Traceability updated
- [x] Safety-relevant impact assessed
- [ ] Documentation updated

## Evidence

Diff is three comment lines at the top of the `Makefile`:

```diff
 # Makefile — AEB Stellantis Project (host build)
 #
+# This file is in every vv-*.yml `paths:` filter; bumping a comment
+# here re-triggers all five V&V workflows + publish-vv-reports.yml.
+#
 # Targets (build & test):
```

**Expected CI behaviour on merge into `development`:**

1. All five V&V workflows fire (Makefile is in every `paths:` list).
2. Each runs to completion; the stack job's outcome is unaffected (no source change).
3. `publish-vv-reports.yml` fires once for each completion. The first four exits at "not all triggered V&V workflows have completed yet"; the fifth proceeds through the gate.
4. Aggregator downloads each run's artefact into `site/<module>/development/`, deploys to gh-pages with `keep_files: true`.
5. Net result on gh-pages: one new commit (e.g. `docs(vv): publish V&V reports for development@<sha>`) updating all five `vv_<module>/development/` subtrees.

# Reviewer Notes
- The change is intentionally minimal — three comment lines in `Makefile`. The point of this PR is the CI side effect, not the diff.
- If the aggregator doesn't behave as described in §Evidence, that's a real failure of PR #126 we want to catch *before* it reaches `main`. This PR is effectively a smoke test in production.
- After this merges and we confirm the gh-pages deploy commit lands, the `development → main` PR can be opened and merged with confidence — at that point the same trigger pattern fires on `main` and the three `vv_<module>/main/` 404s close.

# Risks / Open Points
- If the aggregator misbehaves (e.g. workflow-name string drift, gate logic bug, peaceiris auth), the symptom will be visible immediately: either no deploy commit on gh-pages, or a deploy commit with missing subtrees. Either is recoverable by tweaking `publish-vv-reports.yml` and pushing another trigger.
- Touching the Makefile means CI runs for every module — ~5 minutes of runner time. Acceptable cost for the validation.
